### PR TITLE
Allow Prometheus to scape Alertmanager and itself with oauth enabled

### DIFF
--- a/docs/modules/ROOT/pages/references/addon-oauth2-proxy.adoc
+++ b/docs/modules/ROOT/pages/references/addon-oauth2-proxy.adoc
@@ -4,6 +4,8 @@ Adding the `oauth2-proxy` addon will allow you to use the https://github.com/oau
 
 Check the https://oauth2-proxy.github.io/oauth2-proxy/docs/[Oauth2 Proxy docs] for all possible configuration options.
 
+For cluster internal authentication a https://github.com/brancz/kube-rbac-proxy[brancz/kube-rbac-proxy] sidecar is also deployed.
+
 The addon adds the following configuration options under the `INSTANCE.prometheus.config._oauth2Proxy` and `INSTANCE.alertmanager.config._oauth2Proxy` key:
 
 == `ingress.enabled`

--- a/tests/golden/oauth2-proxy/prometheus/prometheus/20_default-instance_prometheus_clusterRoleBindingProxy.yaml
+++ b/tests/golden/oauth2-proxy/prometheus/prometheus/20_default-instance_prometheus_clusterRoleBindingProxy.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: default-instance
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.32.1
+  name: prometheus-default-instance-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-default-instance-proxy
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-default-instance
+    namespace: syn-prometheus

--- a/tests/golden/oauth2-proxy/prometheus/prometheus/20_default-instance_prometheus_clusterRoleProxy.yaml
+++ b/tests/golden/oauth2-proxy/prometheus/prometheus/20_default-instance_prometheus_clusterRoleProxy.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: default-instance
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.32.1
+  name: prometheus-default-instance-proxy
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create

--- a/tests/golden/oauth2-proxy/prometheus/prometheus/20_default-instance_prometheus_prometheus.yaml
+++ b/tests/golden/oauth2-proxy/prometheus/prometheus/20_default-instance_prometheus_prometheus.yaml
@@ -46,9 +46,30 @@ spec:
       image: quay.io/oauth2-proxy/oauth2-proxy:v7.2.1
       name: oauth2-proxy
       resources:
+        limits:
+          cpu: 500m
+          memory: 128Mi
         requests:
-          cpu: 20m
-          memory: 100Mi
+          cpu: 5m
+          memory: 64Mi
+    - args:
+        - --logtostderr=true
+        - --secure-listen-address=0.0.0.0:4181
+        - --upstream=http://127.0.0.1:9090
+        - --v=0
+      image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+      name: kube-rbac-proxy
+      ports:
+        - containerPort: 4181
+          name: rbac
+          protocol: TCP
+      resources:
+        limits:
+          cpu: 500m
+          memory: 128Mi
+        requests:
+          cpu: 5m
+          memory: 64Mi
   enableFeatures: []
   externalLabels: {}
   image: quay.io/prometheus/prometheus:v2.32.1

--- a/tests/golden/oauth2-proxy/prometheus/prometheus/20_default-instance_prometheus_service.yaml
+++ b/tests/golden/oauth2-proxy/prometheus/prometheus/20_default-instance_prometheus_service.yaml
@@ -20,6 +20,9 @@ spec:
     - name: reloader-web
       port: 8080
       targetPort: reloader-web
+    - name: rbac
+      port: 4181
+      targetPort: 4181
   selector:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/instance: default-instance

--- a/tests/golden/oauth2-proxy/prometheus/prometheus/20_default-instance_prometheus_serviceMonitor.yaml
+++ b/tests/golden/oauth2-proxy/prometheus/prometheus/20_default-instance_prometheus_serviceMonitor.yaml
@@ -14,8 +14,12 @@ metadata:
   namespace: syn-prometheus
 spec:
   endpoints:
-    - interval: 30s
-      port: web
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      path: /metrics
+      port: rbac
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
     - interval: 30s
       port: reloader-web
   selector:

--- a/tests/golden/oauth2-proxy/prometheus/prometheus/30_default-instance_alertmanager_alertmanager.yaml
+++ b/tests/golden/oauth2-proxy/prometheus/prometheus/30_default-instance_alertmanager_alertmanager.yaml
@@ -40,9 +40,30 @@ spec:
       image: quay.io/oauth2-proxy/oauth2-proxy:v7.2.1
       name: oauth2-proxy
       resources:
+        limits:
+          cpu: 500m
+          memory: 128Mi
         requests:
-          cpu: 20m
-          memory: 100Mi
+          cpu: 5m
+          memory: 64Mi
+    - args:
+        - --logtostderr=true
+        - --secure-listen-address=0.0.0.0:4181
+        - --upstream=http://127.0.0.1:9093
+        - --v=0
+      image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+      name: kube-rbac-proxy
+      ports:
+        - containerPort: 4181
+          name: rbac
+          protocol: TCP
+      resources:
+        limits:
+          cpu: 500m
+          memory: 128Mi
+        requests:
+          cpu: 5m
+          memory: 64Mi
   image: quay.io/prometheus/alertmanager:v0.23.0
   listenLocal: true
   nodeSelector:

--- a/tests/golden/oauth2-proxy/prometheus/prometheus/30_default-instance_alertmanager_clusterRoleBindingProxy.yaml
+++ b/tests/golden/oauth2-proxy/prometheus/prometheus/30_default-instance_alertmanager_clusterRoleBindingProxy.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/component: alert-router
+    app.kubernetes.io/instance: alertmanager-default-instance
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: alertmanager
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.23.0
+  name: alertmanager-alertmanager-default-instance-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alertmanager-alertmanager-default-instance-proxy
+subjects:
+  - kind: ServiceAccount
+    name: alertmanager-alertmanager-default-instance
+    namespace: syn-prometheus

--- a/tests/golden/oauth2-proxy/prometheus/prometheus/30_default-instance_alertmanager_clusterRoleProxy.yaml
+++ b/tests/golden/oauth2-proxy/prometheus/prometheus/30_default-instance_alertmanager_clusterRoleProxy.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/component: alert-router
+    app.kubernetes.io/instance: alertmanager-default-instance
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: alertmanager
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.23.0
+  name: alertmanager-alertmanager-default-instance-proxy
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create

--- a/tests/golden/oauth2-proxy/prometheus/prometheus/30_default-instance_alertmanager_service.yaml
+++ b/tests/golden/oauth2-proxy/prometheus/prometheus/30_default-instance_alertmanager_service.yaml
@@ -20,6 +20,9 @@ spec:
     - name: reloader-web
       port: 8080
       targetPort: reloader-web
+    - name: rbac
+      port: 4181
+      targetPort: 4181
   selector:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/instance: alertmanager-default-instance

--- a/tests/golden/oauth2-proxy/prometheus/prometheus/30_default-instance_alertmanager_serviceMonitor.yaml
+++ b/tests/golden/oauth2-proxy/prometheus/prometheus/30_default-instance_alertmanager_serviceMonitor.yaml
@@ -14,8 +14,12 @@ metadata:
   namespace: syn-prometheus
 spec:
   endpoints:
-    - interval: 30s
-      port: web
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      path: /metrics
+      port: rbac
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
     - interval: 30s
       port: reloader-web
   selector:


### PR DESCRIPTION
Deploys a rbac proxy for internal cluster authentication.

![image](https://user-images.githubusercontent.com/1249775/170208418-a32c076f-3054-4778-b213-7da339762f3c.png)

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
