### PR TITLE
Add addon for nodeexporter on OpenShift

### DIFF
--- a/component/addons/nodeexporter-scc.libsonnet
+++ b/component/addons/nodeexporter-scc.libsonnet
@@ -1,0 +1,66 @@
+// This addon adds a security context constain to give the nodeExporter the necessary permissions
+local kube = import 'lib/kube.libjsonnet';
+
+{
+  local config = self,
+  local sccName = '%s-%s' % [ config.values.common.namespace, config.values.nodeExporter.name ],
+  nodeExporter+: {
+    securityContextConstraints: {
+      allowHostDirVolumePlugin: true,
+      allowHostIPC: false,
+      allowHostNetwork: true,
+      allowHostPID: true,
+      allowHostPorts: true,
+      allowPrivilegeEscalation: true,
+      allowPrivilegedContainer: true,
+      allowedCapabilities: null,
+      defaultAddCapabilities: null,
+      apiVersion: 'security.openshift.io/v1',
+      kind: 'SecurityContextConstraints',
+      metadata: {
+        annotations: {
+          'kubernetes.io/description': 'node-exporter scc is used for the Prometheus node exporter',
+        },
+        name: sccName,
+      },
+      readOnlyRootFilesystem: false,
+      requiredDropCapabilities: null,
+      runAsUser: {
+        type: 'RunAsAny',
+      },
+      seLinuxContext: {
+        type: 'RunAsAny',
+      },
+      supplementalGroups: {
+        type: 'RunAsAny',
+      },
+      users: [],
+      volumes: [ '*' ],
+    },
+
+    local sccRole = kube.Role(config.values.nodeExporter.name) {
+      metadata+: {
+        namespace: config.values.common.namespace,
+      },
+      rules: [
+        {
+          apiGroups: [ 'security.openshift.io' ],
+          resourceNames: [ sccName ],
+          resources: [ 'securitycontextconstraints' ],
+          verbs: [ 'use' ],
+        },
+      ],
+    },
+    securityContextRole: sccRole,
+    securityContextRolebinding: kube.RoleBinding(config.values.nodeExporter.name) {
+      metadata+: {
+        namespace: config.values.common.namespace,
+      },
+      roleRef_: sccRole,
+      subjects_: [
+        config.nodeExporter.serviceAccount,
+      ],
+    },
+  },
+
+}

--- a/component/addons/openshift4-nodeexporter.libsonnet
+++ b/component/addons/openshift4-nodeexporter.libsonnet
@@ -3,6 +3,14 @@ local kube = import 'lib/kube.libjsonnet';
 
 {
   local config = self,
+
+  values+:: {
+    nodeExporter+: {
+      port: 9101,  // Change default port as OCP's monitoring stack already uses 9100
+    },
+  },
+
+
   local sccName = '%s-%s' % [ config.values.common.namespace, config.values.nodeExporter.name ],
   nodeExporter+: {
     securityContextConstraints: {

--- a/component/addons/openshift4.libsonnet
+++ b/component/addons/openshift4.libsonnet
@@ -2,7 +2,10 @@
 // It:
 // - patches the upstream ServiceMonitors to work with OpenShift.
 // - adds the `remove-securitycontext` addon to remove the security context from deployments.
+// - adds the `nodeexporter-scc` addon to assign a sufficient SCC to the nodeexporter service account.
 
 (import './remove-securitycontext.libsonnet')
++
+(import './nodeexporter-scc.libsonnet')
 +
 (import './openshift4-control-plane.libsonnet')

--- a/component/addons/openshift4.libsonnet
+++ b/component/addons/openshift4.libsonnet
@@ -2,10 +2,10 @@
 // It:
 // - patches the upstream ServiceMonitors to work with OpenShift.
 // - adds the `remove-securitycontext` addon to remove the security context from deployments.
-// - adds the `nodeexporter-scc` addon to assign a sufficient SCC to the nodeexporter service account.
+// - adds the `nodeexporter` addon to assign a sufficient SCC to the nodeexporter service account and change the default nodeexporter port.
 
 (import './remove-securitycontext.libsonnet')
 +
-(import './nodeexporter-scc.libsonnet')
+(import './openshift4-nodeexporter.libsonnet')
 +
 (import './openshift4-control-plane.libsonnet')

--- a/docs/modules/ROOT/pages/how-tos/openshift.adoc
+++ b/docs/modules/ROOT/pages/how-tos/openshift.adoc
@@ -1,0 +1,43 @@
+= Using this Component on OpenShift
+
+You can use this component on OpenShift.
+However there are a few things to consider to do so.
+
+First and foremost, OpenShift4 comes with it's own Prometheus Operator.
+This means that the Prometheus Operator CRDs are already present.
+You need to first make sure that the installed CRDs are compatible with the operator version you are about to install and disable CRD installation in this component
+
+Next you need to enable the `openshift4` addon.
+It comes with changes to multiple components which are necessary to properly run on OpenShift4.
+
+Finally if you deploy your own node exporter, you will need to remove the default node selector from the namespace in which it will be deployed.
+Otherwise it won't be schedulable on master or infrastructure nodes.
+
+.Example
+[source,yaml]
+----
+parameters:
+  prometheus:
+    kubernetes_version: '1.22'
+    instances:
+      default-instance:
+        common:
+          namespace: default-instance
+        prometheus:
+          enabled: true
+        nodeExporter:
+          enabled: true
+    addons:
+      - openshift4 <1>
+
+    namespaces:
+      default-instance:
+        annotations:
+          openshift.io/node-selector: "" <2>
+
+    prometheusOperator:
+      installCRDs: false <3>
+----
+<1> Enable the `openshift4` addon
+<2> Remove the default node selector
+<3> Don't install CRDs

--- a/docs/modules/ROOT/pages/how-tos/openshift.adoc
+++ b/docs/modules/ROOT/pages/how-tos/openshift.adoc
@@ -5,7 +5,7 @@ However there are a few things to consider to do so.
 
 First and foremost, OpenShift4 comes with it's own Prometheus Operator.
 This means that the Prometheus Operator CRDs are already present.
-You need to first make sure that the installed CRDs are compatible with the operator version you are about to install and disable CRD installation in this component
+You need to first make sure that the installed CRDs are compatible with the operator version you are about to install and disable CRD installation in this component.
 
 Next you need to enable the `openshift4` addon.
 It comes with changes to multiple components which are necessary to properly run on OpenShift4.

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -6,4 +6,5 @@
 
 .How-Tos
 * xref:how-tos/prometheus.adoc[Deploy Prometheus]
+* xref:how-tos/openshift.adoc[OpenShift]
 * xref:how-tos/setup-keycloak.adoc[Setup with Keycloak]

--- a/tests/golden/openshift/prometheus/prometheus/00_namespace_default-instance.yaml
+++ b/tests/golden/openshift/prometheus/prometheus/00_namespace_default-instance.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations: {}
+  annotations:
+    openshift.io/node-selector: ''
   labels:
     name: default-instance
   name: default-instance

--- a/tests/golden/openshift/prometheus/prometheus/50_default-instance_nodeExporter_daemonset.yaml
+++ b/tests/golden/openshift/prometheus/prometheus/50_default-instance_nodeExporter_daemonset.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - args:
-            - --web.listen-address=127.0.0.1:9100
+            - --web.listen-address=127.0.0.1:9101
             - --path.sysfs=/host/sys
             - --path.rootfs=/host/root
             - --no-collector.wifi
@@ -57,9 +57,9 @@ spec:
               readOnly: true
         - args:
             - --logtostderr
-            - --secure-listen-address=[$(IP)]:9100
+            - --secure-listen-address=[$(IP)]:9101
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-            - --upstream=http://127.0.0.1:9100/
+            - --upstream=http://127.0.0.1:9101/
           env:
             - name: IP
               valueFrom:
@@ -68,8 +68,8 @@ spec:
           image: quay.io/brancz/kube-rbac-proxy:v0.11.0
           name: kube-rbac-proxy
           ports:
-            - containerPort: 9100
-              hostPort: 9100
+            - containerPort: 9101
+              hostPort: 9101
               name: https
           resources:
             limits:

--- a/tests/golden/openshift/prometheus/prometheus/50_default-instance_nodeExporter_securityContextConstraints.yaml
+++ b/tests/golden/openshift/prometheus/prometheus/50_default-instance_nodeExporter_securityContextConstraints.yaml
@@ -1,0 +1,30 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: node-exporter scc is used for the Prometheus node exporter
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: syn
+  name: syn-prometheus-nodeexporter-default-instance
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+  - '*'

--- a/tests/golden/openshift/prometheus/prometheus/50_default-instance_nodeExporter_securityContextRole.yaml
+++ b/tests/golden/openshift/prometheus/prometheus/50_default-instance_nodeExporter_securityContextRole.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: syn
+    name: nodeexporter-default-instance
+  name: nodeexporter-default-instance
+  namespace: syn-prometheus
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - syn-prometheus-nodeexporter-default-instance
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/tests/golden/openshift/prometheus/prometheus/50_default-instance_nodeExporter_securityContextRolebinding.yaml
+++ b/tests/golden/openshift/prometheus/prometheus/50_default-instance_nodeExporter_securityContextRolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: syn
+    name: nodeexporter-default-instance
+  name: nodeexporter-default-instance
+  namespace: syn-prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nodeexporter-default-instance
+subjects:
+  - kind: ServiceAccount
+    name: nodeexporter-default-instance
+    namespace: syn-prometheus

--- a/tests/golden/openshift/prometheus/prometheus/50_default-instance_nodeExporter_service.yaml
+++ b/tests/golden/openshift/prometheus/prometheus/50_default-instance_nodeExporter_service.yaml
@@ -15,7 +15,7 @@ spec:
   clusterIP: None
   ports:
     - name: https
-      port: 9100
+      port: 9101
       targetPort: https
   selector:
     app.kubernetes.io/component: exporter

--- a/tests/openshift.yml
+++ b/tests/openshift.yml
@@ -26,7 +26,9 @@ parameters:
       - openshift4
 
     namespaces:
-      default-instance: {}
+      default-instance:
+        annotations:
+          openshift.io/node-selector: ""
 
     prometheusOperator:
       installCRDs: false


### PR DESCRIPTION
Adds an addon to add an SCC with the necessary permissions for the node exporter to start on OpenShift. 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
