### PR TITLE
Only restict Prometheus Operator to deploy to configured namespaces

### DIFF
--- a/component/operator.libsonnet
+++ b/component/operator.libsonnet
@@ -18,6 +18,7 @@ local configuredOperator =
       } + com.makeMergeable(params.base.common) + com.makeMergeable(params.prometheusOperator.common),
     } + { prometheusOperator+: com.makeMergeable(params.prometheusOperator.config) },
 
+    local namespaces = std.join(',', std.filter(function(name) params.namespaces[name] != null, std.objectFields(params.namespaces))),
     prometheusOperator+: {
       deployment+: {
         spec+: {
@@ -27,7 +28,9 @@ local configuredOperator =
                 if c.name == config.values.prometheusOperator.name then
                   c {
                     args+: [
-                      '-namespaces=%s' % std.join(',', std.filter(function(name) params.namespaces[name] != null, std.objectFields(params.namespaces))),
+                      '--prometheus-instance-namespaces=%s' % namespaces,
+                      '--thanos-ruler-instance-namespaces=%s' % namespaces,
+                      '--alertmanager-instance-namespaces=%s' % namespaces,
                     ],
                   }
                 else

--- a/tests/golden/defaults/prometheus/prometheus/10_prometheusOperator_deployment.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/10_prometheusOperator_deployment.yaml
@@ -32,7 +32,9 @@ spec:
         - args:
             - --kubelet-service=kube-system/kubelet
             - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.49.0
-            - -namespaces=
+            - --prometheus-instance-namespaces=
+            - --thanos-ruler-instance-namespaces=
+            - --alertmanager-instance-namespaces=
           image: quay.io/prometheus-operator/prometheus-operator:v0.49.0
           name: syn-prometheus-operator
           ports:

--- a/tests/golden/kubernetes_1.20/prometheus/prometheus/10_prometheusOperator_deployment.yaml
+++ b/tests/golden/kubernetes_1.20/prometheus/prometheus/10_prometheusOperator_deployment.yaml
@@ -30,7 +30,9 @@ spec:
         - args:
             - --kubelet-service=kube-system/kubelet
             - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.47.0
-            - -namespaces=
+            - --prometheus-instance-namespaces=
+            - --thanos-ruler-instance-namespaces=
+            - --alertmanager-instance-namespaces=
           image: quay.io/prometheus-operator/prometheus-operator:v0.47.0
           name: syn-prometheus-operator
           ports:

--- a/tests/golden/kubernetes_1.21/prometheus/prometheus/10_prometheusOperator_deployment.yaml
+++ b/tests/golden/kubernetes_1.21/prometheus/prometheus/10_prometheusOperator_deployment.yaml
@@ -32,7 +32,9 @@ spec:
         - args:
             - --kubelet-service=kube-system/kubelet
             - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.49.0
-            - -namespaces=
+            - --prometheus-instance-namespaces=
+            - --thanos-ruler-instance-namespaces=
+            - --alertmanager-instance-namespaces=
           image: quay.io/prometheus-operator/prometheus-operator:v0.49.0
           name: syn-prometheus-operator
           ports:

--- a/tests/golden/kubernetes_1.22/prometheus/prometheus/10_prometheusOperator_deployment.yaml
+++ b/tests/golden/kubernetes_1.22/prometheus/prometheus/10_prometheusOperator_deployment.yaml
@@ -32,7 +32,9 @@ spec:
         - args:
             - --kubelet-service=kube-system/kubelet
             - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.53.1
-            - -namespaces=
+            - --prometheus-instance-namespaces=
+            - --thanos-ruler-instance-namespaces=
+            - --alertmanager-instance-namespaces=
           image: quay.io/prometheus-operator/prometheus-operator:v0.53.1
           name: syn-prometheus-operator
           ports:

--- a/tests/golden/multi/prometheus/prometheus/10_prometheusOperator_deployment.yaml
+++ b/tests/golden/multi/prometheus/prometheus/10_prometheusOperator_deployment.yaml
@@ -32,7 +32,9 @@ spec:
         - args:
             - --kubelet-service=kube-system/kubelet
             - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.49.0
-            - -namespaces=
+            - --prometheus-instance-namespaces=
+            - --thanos-ruler-instance-namespaces=
+            - --alertmanager-instance-namespaces=
           image: quay.io/prometheus-operator/prometheus-operator:v0.49.0
           name: syn-prometheus-operator
           ports:

--- a/tests/golden/openshift/prometheus/prometheus/10_prometheusOperator_deployment.yaml
+++ b/tests/golden/openshift/prometheus/prometheus/10_prometheusOperator_deployment.yaml
@@ -32,7 +32,9 @@ spec:
         - args:
             - --kubelet-service=kube-system/kubelet
             - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.53.1
-            - -namespaces=default-instance
+            - --prometheus-instance-namespaces=default-instance
+            - --thanos-ruler-instance-namespaces=default-instance
+            - --alertmanager-instance-namespaces=default-instance
           image: quay.io/prometheus-operator/prometheus-operator:v0.53.1
           name: syn-prometheus-operator
           ports:

--- a/tests/golden/rewrite-registries/prometheus/prometheus/10_prometheusOperator_deployment.yaml
+++ b/tests/golden/rewrite-registries/prometheus/prometheus/10_prometheusOperator_deployment.yaml
@@ -32,7 +32,9 @@ spec:
         - args:
             - --kubelet-service=kube-system/kubelet
             - --prometheus-config-reloader=quay-io.proxy.com/prometheus-operator/prometheus-config-reloader:v0.49.0
-            - -namespaces=
+            - --prometheus-instance-namespaces=
+            - --thanos-ruler-instance-namespaces=
+            - --alertmanager-instance-namespaces=
           image: quay-io.proxy.com/prometheus-operator/prometheus-operator:v0.49.0
           name: syn-prometheus-operator
           ports:

--- a/tests/golden/thanos/prometheus/prometheus/10_prometheusOperator_deployment.yaml
+++ b/tests/golden/thanos/prometheus/prometheus/10_prometheusOperator_deployment.yaml
@@ -32,7 +32,9 @@ spec:
         - args:
             - --kubelet-service=kube-system/kubelet
             - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.49.0
-            - -namespaces=
+            - --prometheus-instance-namespaces=
+            - --thanos-ruler-instance-namespaces=
+            - --alertmanager-instance-namespaces=
           image: quay.io/prometheus-operator/prometheus-operator:v0.49.0
           name: syn-prometheus-operator
           ports:


### PR DESCRIPTION
We want the Prometheus Operator to only deploy to the created namespaces, but we still want to be able to find monitors and rules in other namespaces.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
