### PR TITLE
Patch Prometheus clusterrole to allow access to registry metrics path

### DIFF
--- a/component/addons/openshift4-registry-metrics-clusterrole.libsonnet
+++ b/component/addons/openshift4-registry-metrics-clusterrole.libsonnet
@@ -1,0 +1,17 @@
+{
+  prometheus+: {
+    clusterRole+: {
+      rules+: [ {
+        apiGroups: [
+          'image.openshift.io',
+        ],
+        resources: [
+          'registry/metrics',
+        ],
+        verbs: [
+          'get',
+        ],
+      } ],
+    },
+  },
+}

--- a/component/addons/openshift4.libsonnet
+++ b/component/addons/openshift4.libsonnet
@@ -12,3 +12,5 @@
 (import './openshift4-control-plane.libsonnet')
 +
 (import './openshift-certs.libsonnet')
++
+(import './openshift4-registry-metrics-clusterrole.libsonnet')

--- a/tests/golden/openshift/prometheus/prometheus/20_default-instance_prometheus_clusterRole.yaml
+++ b/tests/golden/openshift/prometheus/prometheus/20_default-instance_prometheus_clusterRole.yaml
@@ -23,3 +23,9 @@ rules:
       - /metrics
     verbs:
       - get
+  - apiGroups:
+      - image.openshift.io
+    resources:
+      - registry/metrics
+    verbs:
+      - get


### PR DESCRIPTION
Also see https://github.com/appuio/component-openshift4-registry/pull/27

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
