### PR TITLE
Prune ArgoCD Application to remove null namespace

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -19,5 +19,5 @@ local app = argocd.App(instance, null) {
 };
 
 {
-  [instance]: app,
+  [instance]: std.prune(app),
 }


### PR DESCRIPTION
If `spec.destination.namespace` is set to `null`, ArgoCD can't sync this manifest.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.