### PR TITLE
Fix wrong component references in doc

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -11,11 +11,11 @@ Multiple instances of the following components can be configured:
 * prometheus
 * alertmanager
 * grafana
-* node_exporter
-* blackbox_exporter
-* kubernetes_control_plane
-* prometheus_adapter
-* kube_state_metrics
+* nodeExporter
+* blackboxExporter
+* kubernetesControlPlane
+* prometheusAdapter
+* kubeStateMetrics
 
 
 == `kubernetes_version`
@@ -161,23 +161,23 @@ grafana:
   enabled: false
   config: {}
   overrides: {}
-node_exporter:
+nodeExporter:
   enabled: false
   config: {}
   overrides: {}
-blackbox_exporter:
+blackboxExporter:
   enabled: false
   config: {}
   overrides: {}
-kubernetes_control_plane:
+kubernetesControlPlane:
   enabled: false
   config: {}
   overrides: {}
-prometheus_adapter:
+prometheusAdapter:
   enabled: false
   config: {}
   overrides: {}
-kube_state_metrics:
+kubeStateMetrics:
   enabled: false
   config: {}
   overrides: {}
@@ -216,7 +216,7 @@ infra:
       scrape_interval: 15s
       scrape_timeout: 10s
       evaluation_interval: 15s
-  node_exporter:
+  nodeExporter:
     enabled: true
 ----
 


### PR DESCRIPTION
The individual components are named wrong in the docs. The names are camel case and not snake case.

Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>




## Checklist

- [ ] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
