### PR TITLE
Add and enable addon to disable rules

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -3,12 +3,12 @@ parameters:
     # Dependency resolution
     jsonnetfile_parameters:
       kube_prometheus_version: ${prometheus:_kube_prometheus_version:${prometheus:kubernetes_version}}
-    kubernetes_version: '1.21'
+    kubernetes_version: "1.21"
 
     registries:
-      docker.io: 'docker.io'
-      quay.io: 'quay.io'
-      k8s.gcr.io: 'k8s.gcr.io'
+      docker.io: "docker.io"
+      quay.io: "quay.io"
+      k8s.gcr.io: "k8s.gcr.io"
 
     images:
       oauth2Proxy:
@@ -33,7 +33,15 @@ parameters:
 
     secrets: {}
 
-    addons: []
+    addons:
+      - disable-alerts
+    addon_configs:
+      disable_alerts:
+        # List of alertnames to exclude from the final ruleset
+        ignoreNames:
+          - KubeHpaMaxedOut
+          - KubeHpaReplicasMismatch
+          - CPUThrottlingHigh
 
     base:
       common:

--- a/component/addons/disable-alerts.libsonnet
+++ b/component/addons/disable-alerts.libsonnet
@@ -1,0 +1,48 @@
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local inv = kap.inventory();
+local params = inv.parameters.prometheus;
+
+local ruleFilter(group) =
+  // merge user-provided and hard-coded rule names to filter out
+  local ignoreSet = std.set(com.renderArray(params.addon_configs.disable_alerts.ignoreNames));
+
+  // return group object, with filtered rules list
+  group {
+    rules: std.filter(
+      function(rule)
+        // never filter rules which don't have the `alert` field, those are
+        // probably recording rules.
+        !std.objectHas(rule, 'alert') ||
+        // filter out rules which are in our set of rules to ignore
+        !std.member(ignoreSet, rule.alert),
+      group.rules
+    ),
+  };
+
+local components = [
+  'alertmanager',
+  'blackboxExporter',
+  'grafana',
+  'kubernetesControlPlane',
+  'kubePrometheus',
+  'kubeStateMetrics',
+  'nodeExporter',
+  'prometheusAdapter',
+  'prometheusOperator',
+  'prometheus',
+];
+
+std.foldl(function(obj, name) obj {
+  [name]+: {
+    prometheusRule+: {
+      spec+: {
+        local g = super.groups,
+        groups: std.map(
+          ruleFilter,
+          g
+        ),
+      },
+    },
+  },
+}, components, {})

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -113,13 +113,19 @@ local enableAlert(name, object) =
     lib.Enable(object)
   else object;
 
+local removePartialManifests(obj) = {
+  [k]: obj[k]
+  for k in std.objectFields(obj)
+  if std.objectHas(obj[k], 'kind')
+};
+
 (import 'operator.libsonnet')
 + namespaces
 + secrets
 + std.mapWithKey(
   enableAlert,
   std.foldl(
-    function(prev, i) prev + instances[i],
+    function(prev, i) prev + removePartialManifests(instances[i]),
     std.objectFields(instances),
     {}
   )

--- a/docs/modules/ROOT/pages/references/addon-disable-alerts.adoc
+++ b/docs/modules/ROOT/pages/references/addon-disable-alerts.adoc
@@ -1,0 +1,30 @@
+= Addon: Disable Alerts
+
+Adding the `disable-alerts` addon (enabled by default) will allow you to disable alert rules based on their name.
+Furthermore the addon already disables the following alerts by default:
+
+* KubeHpaMaxedOut
+* KubeHpaReplicasMismatch
+* CPUThrottlingHigh
+
+Those alerts usually generate a lot of noice and are therefore removed by default.
+
+The addon adds the following configuration option under the `INSTANCE.addon_configs.disable_alerts` key:
+
+== `ignoreNames`
+
+[horizontal]
+type:: array
+default:: `[]`
+example::
++
+[source,yaml]
+----
+addon_configs:
+  disable_alerts:
+    ignoreNames:
+      -  KubeCPUOvercommit
+----
+
+List of alert names to disable completely.
+Entries added previously in the hierarchy can be removed again by prefixing them with `~`.

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -3,6 +3,7 @@
 
 .Addons
 ** xref:references/addon-oauth2-proxy.adoc[OAuth2 Proxy]
+** xref:references/addon-disable-alerts.adoc[Disable Alerts]
 
 .How-Tos
 * xref:how-tos/prometheus.adoc[Deploy Prometheus]

--- a/tests/golden/kubernetes_1.20/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.20/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -193,35 +193,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: KubeHpaReplicasMismatch
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.hpa }} has not matched
-              the desired number of replicas for longer than 15 minutes.
-            runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/kubehpareplicasmismatch
-            summary: HPA has not matched descired number of replicas.
-          expr: "(kube_horizontalpodautoscaler_status_desired_replicas{job=\"kube-state-metrics\"\
-            }\n  !=\nkube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            })\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  >\nkube_horizontalpodautoscaler_spec_min_replicas{job=\"\
-            kube-state-metrics\"})\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  <\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"\
-            kube-state-metrics\"})\n  and\nchanges(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}[15m]) == 0\n"
-          for: 15m
-          labels:
-            severity: warning
-        - alert: KubeHpaMaxedOut
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.hpa }} has been running
-              at max replicas for longer than 15 minutes.
-            runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/kubehpamaxedout
-            summary: HPA is running at max replicas
-          expr: "kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            }\n  ==\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\"\
-            }\n"
-          for: 15m
-          labels:
-            severity: warning
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -308,19 +279,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: CPUThrottlingHigh
-          annotations:
-            description: '{{ $value | humanizePercentage }} throttling of CPU in namespace
-              {{ $labels.namespace }} for container {{ $labels.container }} in pod
-              {{ $labels.pod }}.'
-            runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/cputhrottlinghigh
-            summary: Processes experience elevated CPU throttling.
-          expr: "sum(increase(container_cpu_cfs_throttled_periods_total{container!=\"\
-            \", }[5m])) by (container, pod, namespace)\n  /\nsum(increase(container_cpu_cfs_periods_total{}[5m]))\
-            \ by (container, pod, namespace)\n  > ( 25 / 100 )\n"
-          for: 15m
-          labels:
-            severity: info
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp

--- a/tests/golden/kubernetes_1.21/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.21/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -193,35 +193,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: KubeHpaReplicasMismatch
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
-              has not matched the desired number of replicas for longer than 15 minutes.
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpareplicasmismatch
-            summary: HPA has not matched descired number of replicas.
-          expr: "(kube_horizontalpodautoscaler_status_desired_replicas{job=\"kube-state-metrics\"\
-            }\n  !=\nkube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            })\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  >\nkube_horizontalpodautoscaler_spec_min_replicas{job=\"\
-            kube-state-metrics\"})\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  <\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"\
-            kube-state-metrics\"})\n  and\nchanges(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}[15m]) == 0\n"
-          for: 15m
-          labels:
-            severity: warning
-        - alert: KubeHpaMaxedOut
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
-              has been running at max replicas for longer than 15 minutes.
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpamaxedout
-            summary: HPA is running at max replicas
-          expr: "kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            }\n  ==\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\"\
-            }\n"
-          for: 15m
-          labels:
-            severity: warning
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -319,19 +290,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: CPUThrottlingHigh
-          annotations:
-            description: '{{ $value | humanizePercentage }} throttling of CPU in namespace
-              {{ $labels.namespace }} for container {{ $labels.container }} in pod
-              {{ $labels.pod }}.'
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/cputhrottlinghigh
-            summary: Processes experience elevated CPU throttling.
-          expr: "sum(increase(container_cpu_cfs_throttled_periods_total{container!=\"\
-            \", }[5m])) by (container, pod, namespace)\n  /\nsum(increase(container_cpu_cfs_periods_total{}[5m]))\
-            \ by (container, pod, namespace)\n  > ( 25 / 100 )\n"
-          for: 15m
-          labels:
-            severity: info
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp

--- a/tests/golden/kubernetes_1.22/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.22/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -194,35 +194,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: KubeHpaReplicasMismatch
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
-              has not matched the desired number of replicas for longer than 15 minutes.
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpareplicasmismatch
-            summary: HPA has not matched descired number of replicas.
-          expr: "(kube_horizontalpodautoscaler_status_desired_replicas{job=\"kube-state-metrics\"\
-            }\n  !=\nkube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            })\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  >\nkube_horizontalpodautoscaler_spec_min_replicas{job=\"\
-            kube-state-metrics\"})\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  <\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"\
-            kube-state-metrics\"})\n  and\nchanges(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}[15m]) == 0\n"
-          for: 15m
-          labels:
-            severity: warning
-        - alert: KubeHpaMaxedOut
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
-              has been running at max replicas for longer than 15 minutes.
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpamaxedout
-            summary: HPA is running at max replicas
-          expr: "kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            }\n  ==\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\"\
-            }\n"
-          for: 15m
-          labels:
-            severity: warning
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -320,19 +291,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: CPUThrottlingHigh
-          annotations:
-            description: '{{ $value | humanizePercentage }} throttling of CPU in namespace
-              {{ $labels.namespace }} for container {{ $labels.container }} in pod
-              {{ $labels.pod }}.'
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/cputhrottlinghigh
-            summary: Processes experience elevated CPU throttling.
-          expr: "sum(increase(container_cpu_cfs_throttled_periods_total{container!=\"\
-            \", }[5m])) by (container, pod, namespace)\n  /\nsum(increase(container_cpu_cfs_periods_total{}[5m]))\
-            \ by (container, pod, namespace)\n  > ( 25 / 100 )\n"
-          for: 15m
-          labels:
-            severity: info
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp

--- a/tests/golden/kubernetes_1.23/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.23/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -193,35 +193,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: KubeHpaReplicasMismatch
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
-              has not matched the desired number of replicas for longer than 15 minutes.
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpareplicasmismatch
-            summary: HPA has not matched descired number of replicas.
-          expr: "(kube_horizontalpodautoscaler_status_desired_replicas{job=\"kube-state-metrics\"\
-            }\n  !=\nkube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            })\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  >\nkube_horizontalpodautoscaler_spec_min_replicas{job=\"\
-            kube-state-metrics\"})\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  <\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"\
-            kube-state-metrics\"})\n  and\nchanges(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}[15m]) == 0\n"
-          for: 15m
-          labels:
-            severity: warning
-        - alert: KubeHpaMaxedOut
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
-              has been running at max replicas for longer than 15 minutes.
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpamaxedout
-            summary: HPA is running at max replicas
-          expr: "kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            }\n  ==\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\"\
-            }\n"
-          for: 15m
-          labels:
-            severity: warning
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -319,19 +290,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: CPUThrottlingHigh
-          annotations:
-            description: '{{ $value | humanizePercentage }} throttling of CPU in namespace
-              {{ $labels.namespace }} for container {{ $labels.container }} in pod
-              {{ $labels.pod }}.'
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/cputhrottlinghigh
-            summary: Processes experience elevated CPU throttling.
-          expr: "sum(increase(container_cpu_cfs_throttled_periods_total{container!=\"\
-            \", }[5m])) by (container, pod, namespace)\n  /\nsum(increase(container_cpu_cfs_periods_total{}[5m]))\
-            \ by (container, pod, namespace)\n  > ( 25 / 100 )\n"
-          for: 15m
-          labels:
-            severity: info
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp

--- a/tests/golden/kubernetes_1.24/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.24/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -193,35 +193,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: KubeHpaReplicasMismatch
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
-              has not matched the desired number of replicas for longer than 15 minutes.
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpareplicasmismatch
-            summary: HPA has not matched descired number of replicas.
-          expr: "(kube_horizontalpodautoscaler_status_desired_replicas{job=\"kube-state-metrics\"\
-            }\n  !=\nkube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            })\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  >\nkube_horizontalpodautoscaler_spec_min_replicas{job=\"\
-            kube-state-metrics\"})\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  <\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"\
-            kube-state-metrics\"})\n  and\nchanges(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}[15m]) == 0\n"
-          for: 15m
-          labels:
-            severity: warning
-        - alert: KubeHpaMaxedOut
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
-              has been running at max replicas for longer than 15 minutes.
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpamaxedout
-            summary: HPA is running at max replicas
-          expr: "kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            }\n  ==\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\"\
-            }\n"
-          for: 15m
-          labels:
-            severity: warning
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -319,19 +290,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: CPUThrottlingHigh
-          annotations:
-            description: '{{ $value | humanizePercentage }} throttling of CPU in namespace
-              {{ $labels.namespace }} for container {{ $labels.container }} in pod
-              {{ $labels.pod }}.'
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/cputhrottlinghigh
-            summary: Processes experience elevated CPU throttling.
-          expr: "sum(increase(container_cpu_cfs_throttled_periods_total{container!=\"\
-            \", }[5m])) by (container, pod, namespace)\n  /\nsum(increase(container_cpu_cfs_periods_total{}[5m]))\
-            \ by (container, pod, namespace)\n  > ( 25 / 100 )\n"
-          for: 15m
-          labels:
-            severity: info
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp

--- a/tests/golden/openshift/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/openshift/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -194,35 +194,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: KubeHpaReplicasMismatch
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
-              has not matched the desired number of replicas for longer than 15 minutes.
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpareplicasmismatch
-            summary: HPA has not matched descired number of replicas.
-          expr: "(kube_horizontalpodautoscaler_status_desired_replicas{job=\"kube-state-metrics\"\
-            }\n  !=\nkube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            })\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  >\nkube_horizontalpodautoscaler_spec_min_replicas{job=\"\
-            kube-state-metrics\"})\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  <\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"\
-            kube-state-metrics\"})\n  and\nchanges(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}[15m]) == 0\n"
-          for: 15m
-          labels:
-            severity: warning
-        - alert: KubeHpaMaxedOut
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
-              has been running at max replicas for longer than 15 minutes.
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpamaxedout
-            summary: HPA is running at max replicas
-          expr: "kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            }\n  ==\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\"\
-            }\n"
-          for: 15m
-          labels:
-            severity: warning
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -320,19 +291,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: CPUThrottlingHigh
-          annotations:
-            description: '{{ $value | humanizePercentage }} throttling of CPU in namespace
-              {{ $labels.namespace }} for container {{ $labels.container }} in pod
-              {{ $labels.pod }}.'
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/cputhrottlinghigh
-            summary: Processes experience elevated CPU throttling.
-          expr: "sum(increase(container_cpu_cfs_throttled_periods_total{container!=\"\
-            \", }[5m])) by (container, pod, namespace)\n  /\nsum(increase(container_cpu_cfs_periods_total{}[5m]))\
-            \ by (container, pod, namespace)\n  > ( 25 / 100 )\n"
-          for: 15m
-          labels:
-            severity: info
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp

--- a/tests/golden/rewrite-registries/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/rewrite-registries/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -193,35 +193,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: KubeHpaReplicasMismatch
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
-              has not matched the desired number of replicas for longer than 15 minutes.
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpareplicasmismatch
-            summary: HPA has not matched descired number of replicas.
-          expr: "(kube_horizontalpodautoscaler_status_desired_replicas{job=\"kube-state-metrics\"\
-            }\n  !=\nkube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            })\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  >\nkube_horizontalpodautoscaler_spec_min_replicas{job=\"\
-            kube-state-metrics\"})\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}\n  <\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"\
-            kube-state-metrics\"})\n  and\nchanges(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
-            kube-state-metrics\"}[15m]) == 0\n"
-          for: 15m
-          labels:
-            severity: warning
-        - alert: KubeHpaMaxedOut
-          annotations:
-            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
-              has been running at max replicas for longer than 15 minutes.
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpamaxedout
-            summary: HPA is running at max replicas
-          expr: "kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
-            }\n  ==\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\"\
-            }\n"
-          for: 15m
-          labels:
-            severity: warning
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -319,19 +290,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: CPUThrottlingHigh
-          annotations:
-            description: '{{ $value | humanizePercentage }} throttling of CPU in namespace
-              {{ $labels.namespace }} for container {{ $labels.container }} in pod
-              {{ $labels.pod }}.'
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/cputhrottlinghigh
-            summary: Processes experience elevated CPU throttling.
-          expr: "sum(increase(container_cpu_cfs_throttled_periods_total{container!=\"\
-            \", }[5m])) by (container, pod, namespace)\n  /\nsum(increase(container_cpu_cfs_periods_total{}[5m]))\
-            \ by (container, pod, namespace)\n  > ( 25 / 100 )\n"
-          for: 15m
-          labels:
-            severity: info
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp


### PR DESCRIPTION
This new addon allows, to disable alerts by their name. Furthermore it disables certain alerts by default.

Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>




## Checklist

- [ ] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
