### PR TITLE
Mount Alertmanager ServiceAccount token for kube-rbac-proxy

### DIFF
--- a/component/addons/oauth2-proxy.libsonnet
+++ b/component/addons/oauth2-proxy.libsonnet
@@ -271,6 +271,12 @@ proxyFor('alertmanager') + proxyFor('prometheus') + {
     },
   },
 
+  alertmanager+: {
+    serviceAccount+: {
+      automountServiceAccountToken: true,
+    },
+  },
+
   prometheus+: {
     prometheus+: {
       spec+: {

--- a/tests/golden/additional_rules/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/additional_rules/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -120,11 +120,11 @@ spec:
           expr: "(\n  (\n    kube_daemonset_status_current_number_scheduled{job=\"\
             kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"\
             kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_misscheduled{job=\"\
-            kube-state-metrics\"}\n     !=\n    0\n  ) or (\n    kube_daemonset_updated_number_scheduled{job=\"\
+            kube-state-metrics\"}\n     !=\n    0\n  ) or (\n    kube_daemonset_status_updated_number_scheduled{job=\"\
             kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"\
             kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_available{job=\"\
             kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"\
-            kube-state-metrics\"}\n  )\n) and (\n  changes(kube_daemonset_updated_number_scheduled{job=\"\
+            kube-state-metrics\"}\n  )\n) and (\n  changes(kube_daemonset_status_updated_number_scheduled{job=\"\
             kube-state-metrics\"}[5m])\n    ==\n  0\n)\n"
           for: 15m
           labels:

--- a/tests/golden/kubernetes_1.21/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.21/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -120,11 +120,11 @@ spec:
           expr: "(\n  (\n    kube_daemonset_status_current_number_scheduled{job=\"\
             kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"\
             kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_misscheduled{job=\"\
-            kube-state-metrics\"}\n     !=\n    0\n  ) or (\n    kube_daemonset_updated_number_scheduled{job=\"\
+            kube-state-metrics\"}\n     !=\n    0\n  ) or (\n    kube_daemonset_status_updated_number_scheduled{job=\"\
             kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"\
             kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_available{job=\"\
             kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"\
-            kube-state-metrics\"}\n  )\n) and (\n  changes(kube_daemonset_updated_number_scheduled{job=\"\
+            kube-state-metrics\"}\n  )\n) and (\n  changes(kube_daemonset_status_updated_number_scheduled{job=\"\
             kube-state-metrics\"}[5m])\n    ==\n  0\n)\n"
           for: 15m
           labels:

--- a/tests/golden/oauth2-proxy/prometheus/prometheus/30_default-instance_alertmanager_serviceAccount.yaml
+++ b/tests/golden/oauth2-proxy/prometheus/prometheus/30_default-instance_alertmanager_serviceAccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:

--- a/tests/golden/rewrite-registries/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/rewrite-registries/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -120,11 +120,11 @@ spec:
           expr: "(\n  (\n    kube_daemonset_status_current_number_scheduled{job=\"\
             kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"\
             kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_misscheduled{job=\"\
-            kube-state-metrics\"}\n     !=\n    0\n  ) or (\n    kube_daemonset_updated_number_scheduled{job=\"\
+            kube-state-metrics\"}\n     !=\n    0\n  ) or (\n    kube_daemonset_status_updated_number_scheduled{job=\"\
             kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"\
             kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_available{job=\"\
             kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"\
-            kube-state-metrics\"}\n  )\n) and (\n  changes(kube_daemonset_updated_number_scheduled{job=\"\
+            kube-state-metrics\"}\n  )\n) and (\n  changes(kube_daemonset_status_updated_number_scheduled{job=\"\
             kube-state-metrics\"}[5m])\n    ==\n  0\n)\n"
           for: 15m
           labels:


### PR DESCRIPTION
kube-rbac-proxy needs to talk to the k8s API for authenticating requests.

Fixes https://github.com/projectsyn/component-prometheus/issues/55.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
