### PR TITLE
Fix Prometheus networkpolicy

### DIFF
--- a/tests/golden/kubernetes_1.23/prometheus/prometheus/20_default-instance_prometheus_networkPolicy.yaml
+++ b/tests/golden/kubernetes_1.23/prometheus/prometheus/20_default-instance_prometheus_networkPolicy.yaml
@@ -32,6 +32,13 @@ spec:
       ports:
         - port: 9090
           protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grafana-default-instance
+      ports:
+        - port: 9090
+          protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/component: prometheus

--- a/tests/golden/kubernetes_1.24/prometheus/prometheus/20_default-instance_prometheus_networkPolicy.yaml
+++ b/tests/golden/kubernetes_1.24/prometheus/prometheus/20_default-instance_prometheus_networkPolicy.yaml
@@ -32,6 +32,13 @@ spec:
       ports:
         - port: 9090
           protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grafana-default-instance
+      ports:
+        - port: 9090
+          protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/component: prometheus


### PR DESCRIPTION
This PR fixes the Network Policy to allow access from Grafana to Prometheus.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
