### PR TITLE
Use and re-export generic library for alert patching (`syn/alerts.libsonnet`)

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,6 +2,9 @@ parameters:
   prometheus:
     =_metadata:
       multi_tenant: true
+      library_aliases:
+        prom.libsonnet: prometheus-prom.libsonnet
+        alert-patching.libsonnet: prometheus-alert-patching.libsonnet
 
     # Dependency resolution
     jsonnetfile_parameters:
@@ -68,10 +71,7 @@ parameters:
         restrict_selectors: true
       disable_alerts:
         # List of alertnames to exclude from the final ruleset
-        ignoreNames:
-          - KubeHpaMaxedOut
-          - KubeHpaReplicasMismatch
-          - CPUThrottlingHigh
+        ignoreNames: ${prometheus:alerts:ignoreNames}
 
     ingressNetworkPolicySource:
       namespaceSelector: {}
@@ -146,6 +146,13 @@ parameters:
       config:
         name: syn-prometheus-operator
       overrides: {}
+
+    alerts:
+      ignoreNames:
+        - KubeHpaMaxedOut
+        - KubeHpaReplicasMismatch
+        - CPUThrottlingHigh
+      customAnnotations: {}
 
     defaultInstance: null
     instances: {}

--- a/component/addons/additional-rules.libsonnet
+++ b/component/addons/additional-rules.libsonnet
@@ -1,30 +1,14 @@
 local kap = import 'lib/kapitan.libjsonnet';
-local kube = import 'lib/kube.libjsonnet';
-local prom = import 'lib/prom.libsonnet';
+local alerts = import 'syn/alerts.libsonnet';
+
 local inv = kap.inventory();
 local params = inv.parameters.prometheus;
+
 {
   prometheus+: {
     prometheusRule+: {
       spec+: {
-        groups+: [
-          {
-            name: group_name,
-            rules: [
-              local rnamekey =
-                local k = std.splitLimit(rname, ':', 1);
-                assert std.member([ 'alert', 'record' ], k[0]) : 'Invalid custom rule key "%s", the component expects that custom rule keys are prefixed with either "alert:" or "record:"' % [ rname ];
-                k;
-              params.addon_configs.additional_rules[group_name][rname] {
-                [rnamekey[0]]: rnamekey[1],
-              }
-              for rname in std.objectFields(params.addon_configs.additional_rules[group_name])
-              if params.addon_configs.additional_rules[group_name][rname] != null
-            ],
-          }
-          for group_name in std.objectFields(params.addon_configs.additional_rules)
-          if params.addon_configs.additional_rules[group_name] != null
-        ],
+        groups+: alerts.renderGroups(params.addon_configs.additional_rules),
       },
     },
   },

--- a/component/addons/disable-alerts.libsonnet
+++ b/component/addons/disable-alerts.libsonnet
@@ -3,23 +3,9 @@ local kap = import 'lib/kapitan.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.prometheus;
 
-local ruleFilter(group) =
-  // merge user-provided and hard-coded rule names to filter out
-  local ignoreSet = std.set(com.renderArray(params.addon_configs.disable_alerts.ignoreNames));
+local alertpatching = import 'lib/prometheus-alert-patching.libsonnet';
 
-  // return group object, with filtered rules list
-  group {
-    rules: std.filter(
-      function(rule)
-        // never filter rules which don't have the `alert` field, those are
-        // probably recording rules.
-        !std.objectHas(rule, 'alert') ||
-        // filter out rules which are in our set of rules to ignore
-        !std.member(ignoreSet, rule.alert),
-      group.rules
-    ),
-  };
-
+local ignoreNames = std.set(com.renderArray(params.addon_configs.disable_alerts.ignoreNames));
 local components = [
   'alertmanager',
   'blackboxExporter',
@@ -37,10 +23,17 @@ std.foldl(function(obj, name) obj {
   [name]+: {
     prometheusRule+: {
       spec+: {
-        local g = super.groups,
+        local groups = super.groups,
         groups: std.map(
-          ruleFilter,
-          g
+          function(g)
+            alertpatching.filterPatchRules(
+              g,
+              ignoreNames=ignoreNames,
+              patches={},
+              preserveRecordingRules=true,
+              patchNames=false
+            ),
+          groups
         ),
       },
     },

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -231,6 +231,47 @@ Can be overridden by the instance-specific configuration.
 General rules and alerts are grouped in the `kubePrometheus` component.
 
 
+== `alerts`
+
+[horizontal]
+type:: object
+
+This parameter holds configurations that are used by component library `prometheus-alert-patching.libsonnet`.
+The configurations are also used by component addons `additional-rules` and `disable-alerts`.
+
+=== `ignoreNames`
+
+[horizontal]
+type:: list
+default:: https://github.com/projectsyn/component-prometheus/blob/master/class/defaults.yml[See `class/defaults.yml`]
+
+A list of alert names to remove when rendering Prometheus rule groups.
+
+=== `customAnnotations`
+
+[horizontal]
+type:: object
+default:: `{}`
+
+This parameter allows users to apply custom annotations on individual alerts.
+
+The object keys are expected to be strings and used as alert names.
+The object values are expected to be objects with string keys and values and are added to the target alert's `annotations`.
+
+==== Example
+
+The following configuration will add (or overwrite) annotation `runbook_url` for alert `PrometheusBadConfig`
+
+[source,yaml]
+----
+parameters:
+  prometheus:
+    alerts:
+      customAnnotations:
+        PrometheusBadConfig:
+          runbook_url: https://hub.syn.tools/prometheus/runbooks/PrometheusBadConfig.html
+----
+
 == `defaultInstance`
 
 [horizontal]

--- a/jsonnetfile.jsonnet
+++ b/jsonnetfile.jsonnet
@@ -18,6 +18,16 @@
       },
       version: 'bf12954197422f36f0803ee217e378ad055f3837',
     },
+    {
+      source: {
+        git: {
+          remote: 'https://github.com/projectsyn/jsonnet-libs',
+          subdir: '',
+        },
+      },
+      version: 'main',
+      name: 'syn',
+    },
   ],
   legacyImports: true,
 }

--- a/lib/prometheus-alert-patching.libsonnet
+++ b/lib/prometheus-alert-patching.libsonnet
@@ -1,0 +1,13 @@
+local com = import 'lib/commodore.libjsonnet';
+
+local inv = com.inventory();
+
+local global_params = std.get(
+  inv.parameters, 'prometheus', { alerts: {} }
+).alerts;
+
+(import 'syn/alerts.libsonnet') {
+  global_alert_params+: global_params {
+    ignoreNames: std.set(com.renderArray(super.ignoreNames)),
+  },
+}

--- a/lib/prometheus-prom.libsonnet
+++ b/lib/prometheus-prom.libsonnet
@@ -1,0 +1,48 @@
+local prom = import 'lib/prometheus.libsonnet';
+
+local alertpatching = import 'lib/prometheus-alert-patching.libsonnet';
+
+{
+  api_version: prom.api_version,
+
+  /**
+  * \brief Helper to create PrometheusRule objects.
+  *
+  * \arg The name of the PrometheusRule.
+  * \return A PrometheusRule object.
+  */
+  PrometheusRule(name): prom.PrometheusRule,
+
+  /**
+  * \brief Helper to create ServiceMonitor objects.
+  *
+  * \arg The name of the ServiceMonitor
+  * \return An empty ServiceMonitor object.
+  */
+  ServiceMonitor(name): prom.ServiceMonitor,
+
+  /**
+  * \brief Function to render rules defined in the hierarchy
+  *
+  * This function assumes that the rules are defined in the hierarchy in an
+  * object whose fields each represent a rule group. The function also
+  * assumes that each rule group is defined as an object which uses scheme
+  * '(alert:|record:)rulename' for the field names.
+  *
+  * \arg name the name for the resulting `PrometheusRule` manifest
+  * \arg rules the object to render as rules
+
+  * \return A single `PrometheusRule` manifest containing the rule groups.
+  */
+  generateRules(name, rules):
+    prom.PrometheusRule(name) {
+      spec: {
+        groups: alertpatching.renderGroups(rules),
+      },
+    },
+
+  Prometheus(name):
+    error "Use component-prometheus's `instances` to create additional Prometheus instances instead of directly creating a `Prometheus` custom resource",
+  Alertmanager(name):
+    error "Use component-prometheus's `instances` to create additional Alertmanager instances instead of directly creating a `Alertmanager` custom resource",
+}

--- a/lib/prometheus.libsonnet
+++ b/lib/prometheus.libsonnet
@@ -200,6 +200,8 @@ local podMonitor(name) = kube._Object(api_version.monitoring, 'PodMonitor', name
 local probe(name) = kube._Object(api_version.monitoring, 'Probe', name);
 
 {
+  api_version: api_version,
+
   RegisterNamespace: registerNamespace,
   NetworkPolicy: networkPolicy,
 

--- a/tests/additional_rules.yml
+++ b/tests/additional_rules.yml
@@ -34,3 +34,8 @@ parameters:
           enabled: true
         kubePrometheus:
           enabled: true
+
+    alerts:
+      customAnnotations:
+        PrometheusBadConfig:
+          runbook_url: https://hub.syn.tools/prometheus/runbooks/PrometheusBadConfig.html

--- a/tests/golden/additional-netpols/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/additional-netpols/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,3 +108,5 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/additional-netpols/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/additional-netpols/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -49,6 +51,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -68,6 +72,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -81,6 +87,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -92,6 +100,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -103,6 +113,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -122,6 +134,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -134,6 +148,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -168,6 +186,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -187,6 +207,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -208,6 +230,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -219,6 +243,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -231,6 +257,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -244,6 +272,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -257,6 +287,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -268,6 +300,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -287,3 +321,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/additional-netpols/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/additional-netpols/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -47,6 +49,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -64,6 +68,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -82,6 +88,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -100,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -115,6 +125,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -137,6 +149,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -159,3 +173,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/additional_kubestatemetrics_args/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/additional_kubestatemetrics_args/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,3 +108,5 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/additional_kubestatemetrics_args/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/additional_kubestatemetrics_args/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/additional_nodeexporter_args/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/additional_nodeexporter_args/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,3 +108,5 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/additional_nodeexporter_args/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/additional_nodeexporter_args/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -71,6 +75,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -86,6 +92,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -105,6 +113,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -124,6 +134,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -139,6 +151,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -154,6 +168,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -166,6 +182,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -178,6 +196,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -188,6 +208,8 @@ spec:
             (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector failed to scrape.
@@ -197,6 +219,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock on {{ $labels.instance }} is out of sync by more than
@@ -218,6 +242,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock on {{ $labels.instance }} is not synchronising. Ensure
@@ -231,6 +257,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' on {{ $labels.instance
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array on {{ $labels.instance
@@ -254,6 +284,8 @@ spec:
             node_md_disks{state="failed"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -267,6 +299,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -280,6 +314,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/additional_rules/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/additional_rules/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -57,6 +61,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/additional_rules/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/additional_rules/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,3 +108,5 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/additional_rules/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/additional_rules/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -22,7 +22,7 @@ spec:
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
               to reload its configuration.
-            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusbadconfig
+            runbook_url: https://hub.syn.tools/prometheus/runbooks/PrometheusBadConfig.html
             summary: Failed Prometheus configuration reload.
           expr: |
             # Without max_over_time, failed scrapes could create false negatives, see
@@ -31,6 +31,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -49,6 +51,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -68,6 +72,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -81,6 +87,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -92,6 +100,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -103,6 +113,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -122,6 +134,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -134,6 +148,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -168,6 +186,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -187,6 +207,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -208,6 +230,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -219,6 +243,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -231,6 +257,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -244,6 +272,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -257,6 +287,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -268,6 +300,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -287,6 +321,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: generic-rules
       rules:
         - alert: ContainerOOMKilled
@@ -297,3 +333,5 @@ spec:
             kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} == 1
           labels:
             severity: devnull
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/additional_rules/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/additional_rules/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -47,6 +49,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -64,6 +68,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -82,6 +88,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -100,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -115,6 +125,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -137,6 +149,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -159,3 +173,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/additional_rules/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/additional_rules/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -71,6 +75,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -86,6 +92,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -105,6 +113,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -124,6 +134,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -139,6 +151,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -154,6 +168,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -166,6 +182,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -178,6 +196,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -188,6 +208,8 @@ spec:
             (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector failed to scrape.
@@ -197,6 +219,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock on {{ $labels.instance }} is out of sync by more than
@@ -218,6 +242,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock on {{ $labels.instance }} is not synchronising. Ensure
@@ -231,6 +257,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' on {{ $labels.instance
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array on {{ $labels.instance
@@ -254,6 +284,8 @@ spec:
             node_md_disks{state="failed"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -267,6 +299,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -280,6 +314,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/additional_rules/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/additional_rules/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -27,6 +27,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -44,6 +46,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -58,6 +62,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -78,6 +84,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -98,6 +106,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -112,6 +122,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -139,6 +151,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -172,6 +186,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeContainerWaiting
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{
@@ -183,6 +199,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -196,6 +214,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -207,6 +227,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobCompletion
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -218,6 +240,8 @@ spec:
           for: 12h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -230,6 +254,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -245,6 +271,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Pods
@@ -258,6 +286,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeCPUQuotaOvercommit
           annotations:
             description: Cluster has overcommitted CPU resource requests for Namespaces.
@@ -271,6 +301,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Namespaces.
@@ -284,6 +316,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -298,6 +332,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -312,6 +348,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -326,6 +364,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp
@@ -346,6 +386,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -367,6 +409,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeErrors
           annotations:
             description: The persistent volume {{ $labels.persistentvolume }} has
@@ -378,6 +422,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system
       rules:
         - alert: KubeVersionMismatch
@@ -391,6 +437,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientErrors
           annotations:
             description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
@@ -405,6 +453,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-slos
       rules:
         - alert: KubeAPIErrorBudgetBurn
@@ -421,6 +471,8 @@ spec:
             long: 1h
             severity: critical
             short: 5m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -435,6 +487,8 @@ spec:
             long: 6h
             severity: critical
             short: 30m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -449,6 +503,8 @@ spec:
             long: 1d
             severity: warning
             short: 2h
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -463,6 +519,8 @@ spec:
             long: 3d
             severity: warning
             short: 6h
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-apiserver
       rules:
         - alert: KubeClientCertificateExpiration
@@ -475,6 +533,8 @@ spec:
             apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientCertificateExpiration
           annotations:
             description: A client certificate used to authenticate to the apiserver
@@ -485,6 +545,8 @@ spec:
             apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AggregatedAPIErrors
           annotations:
             description: An aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -496,6 +558,8 @@ spec:
             sum by(name, namespace)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AggregatedAPIDown
           annotations:
             description: An aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -507,6 +571,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -517,6 +583,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPITerminatedRequests
           annotations:
             description: The apiserver has terminated {{ $value | humanizePercentage
@@ -529,6 +597,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-kubelet
       rules:
         - alert: KubeNodeNotReady
@@ -541,6 +611,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -552,6 +624,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -569,6 +643,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -580,6 +656,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -591,6 +669,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -602,6 +682,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -612,6 +694,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -622,6 +706,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -632,6 +718,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -642,6 +730,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -653,6 +743,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -664,6 +756,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -674,6 +768,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-scheduler
       rules:
         - alert: KubeSchedulerDown
@@ -686,6 +782,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-controller-manager
       rules:
         - alert: KubeControllerManagerDown
@@ -699,6 +797,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-burnrate.rules
       rules:
         - expr: |

--- a/tests/golden/additional_rules/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/additional_rules/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/cluster-monitoring/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/cluster-monitoring/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,3 +108,5 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/cluster-monitoring/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/cluster-monitoring/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -49,6 +51,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -68,6 +72,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -81,6 +87,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -92,6 +100,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -103,6 +113,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -122,6 +134,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -134,6 +148,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -168,6 +186,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -187,6 +207,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -208,6 +230,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -219,6 +243,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -231,6 +257,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -244,6 +272,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -257,6 +287,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -268,6 +300,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -287,3 +321,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/cluster-monitoring/prometheus/prometheus/20_other_instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/cluster-monitoring/prometheus/prometheus/20_other_instance_prometheus_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -49,6 +51,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -68,6 +72,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -81,6 +87,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -92,6 +100,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -103,6 +113,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -122,6 +134,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -134,6 +148,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -168,6 +186,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -187,6 +207,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -208,6 +230,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -219,6 +243,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -231,6 +257,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -244,6 +272,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -257,6 +287,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -268,6 +300,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -287,3 +321,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/defaults/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,3 +108,5 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/grafana-ingress/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/grafana-ingress/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: config-reloaders
       rules:
         - alert: ConfigReloaderSidecarErrors
@@ -110,3 +124,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/grafana-ingress/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
+++ b/tests/golden/grafana-ingress/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: grafana_rules
       rules:
         - expr: |

--- a/tests/golden/grafana-storage/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/grafana-storage/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: config-reloaders
       rules:
         - alert: ConfigReloaderSidecarErrors
@@ -110,3 +124,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/grafana-storage/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
+++ b/tests/golden/grafana-storage/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: grafana_rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.26/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.26/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
         - alert: InfoInhibitor
           annotations:
             description: |
@@ -59,6 +63,8 @@ spec:
             == 1
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -73,6 +79,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/kubernetes_1.26/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.26/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: config-reloaders
       rules:
         - alert: ConfigReloaderSidecarErrors
@@ -110,3 +124,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.26/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.26/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusSDRefreshFailure
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -43,6 +45,8 @@ spec:
           for: 20m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -61,6 +65,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -80,6 +86,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -93,6 +101,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -104,6 +114,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -115,6 +127,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -134,6 +148,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -158,6 +176,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -180,6 +200,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -199,6 +221,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -220,6 +244,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -231,6 +257,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -256,6 +286,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -269,6 +301,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -281,6 +315,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -294,6 +330,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -305,6 +343,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusHighQueryLoad
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} query API
@@ -318,6 +358,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -337,3 +379,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.26/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.26/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -65,6 +69,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -83,6 +89,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -101,6 +109,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -116,6 +126,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -138,6 +150,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -160,3 +174,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.26/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
+++ b/tests/golden/kubernetes_1.26/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
@@ -25996,7 +25996,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26043,7 +26043,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26105,7 +26105,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26152,7 +26152,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26228,7 +26228,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26297,7 +26297,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26367,7 +26367,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26414,7 +26414,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26476,7 +26476,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26590,7 +26590,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26637,7 +26637,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26699,7 +26699,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26746,7 +26746,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26822,7 +26822,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26891,7 +26891,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26961,7 +26961,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27008,7 +27008,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27070,7 +27070,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27193,7 +27193,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27235,7 +27235,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27315,7 +27315,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27371,7 +27371,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27451,7 +27451,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27592,7 +27592,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27752,7 +27752,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27794,7 +27794,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27918,7 +27918,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27960,7 +27960,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28040,7 +28040,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28120,7 +28120,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28200,7 +28200,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28341,7 +28341,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28501,7 +28501,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28543,7 +28543,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28667,7 +28667,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28709,7 +28709,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28789,7 +28789,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28861,7 +28861,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28941,7 +28941,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -29082,7 +29082,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -29242,7 +29242,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -29284,7 +29284,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {

--- a/tests/golden/kubernetes_1.26/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.26/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: grafana_rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.26/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.26/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -72,6 +76,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -88,6 +94,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -107,6 +115,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -126,6 +136,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -142,6 +154,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -158,6 +172,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -170,6 +186,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -182,6 +200,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $labels.instance }} {{ $value | humanizePercentage }}
@@ -192,6 +212,8 @@ spec:
             (node_nf_conntrack_entries{job="nodeexporter-default-instance"} / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector on {{ $labels.instance
@@ -202,6 +224,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock at {{ $labels.instance }} is out of sync by more than
@@ -223,6 +247,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock at {{ $labels.instance }} is not synchronising. Ensure
@@ -236,6 +262,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' at {{ $labels.instance
@@ -248,6 +276,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array at {{ $labels.instance
@@ -259,6 +289,8 @@ spec:
             node_md_disks{state="failed",job="nodeexporter-default-instance",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -272,6 +304,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -285,6 +319,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeCPUHighUsage
           annotations:
             description: |
@@ -296,6 +332,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemSaturation
           annotations:
             description: |
@@ -309,6 +347,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryMajorPagesFaults
           annotations:
             description: |
@@ -321,6 +361,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryHighUtilization
           annotations:
             description: |
@@ -332,6 +374,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeDiskIOSaturation
           annotations:
             description: |
@@ -344,6 +388,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceFailed
           annotations:
             description: Systemd service {{ $labels.name }} has entered failed state
@@ -355,6 +401,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceCrashlooping
           annotations:
             description: Systemd service {{ $labels.name }} has being restarted too
@@ -367,6 +415,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeBondingDegraded
           annotations:
             description: Bonding interface {{ $labels.master }} on {{ $labels.instance
@@ -378,6 +428,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.26/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.26/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -27,6 +27,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -44,6 +46,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -58,6 +62,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -78,6 +84,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentRolloutStuck
           annotations:
             description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -90,6 +98,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -110,6 +120,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -124,6 +136,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -151,6 +165,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -184,6 +200,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeContainerWaiting
           annotations:
             description: pod/{{ $labels.pod }} in namespace {{ $labels.namespace }}
@@ -196,6 +214,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -209,6 +229,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -220,6 +242,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -232,6 +256,8 @@ spec:
             kube_job_status_active{job="kubestatemetrics-default-instance"} > 0) > 43200
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -244,6 +270,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -260,6 +288,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -274,6 +304,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeCPUQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted CPU resource
@@ -288,6 +320,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted memory resource
@@ -302,6 +336,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -316,6 +352,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -330,6 +368,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -344,6 +384,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp
@@ -368,6 +410,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -393,6 +437,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -415,6 +461,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -440,6 +488,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeErrors
           annotations:
             description: The persistent volume {{ $labels.persistentvolume }} has
@@ -451,6 +501,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system
       rules:
         - alert: KubeVersionMismatch
@@ -464,6 +516,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientErrors
           annotations:
             description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
@@ -478,6 +532,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-slos
       rules:
         - alert: KubeAPIErrorBudgetBurn
@@ -494,6 +550,8 @@ spec:
             long: 1h
             severity: critical
             short: 5m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -508,6 +566,8 @@ spec:
             long: 6h
             severity: critical
             short: 30m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -522,6 +582,8 @@ spec:
             long: 1d
             severity: warning
             short: 2h
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -536,6 +598,8 @@ spec:
             long: 3d
             severity: warning
             short: 6h
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-apiserver
       rules:
         - alert: KubeClientCertificateExpiration
@@ -549,6 +613,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientCertificateExpiration
           annotations:
             description: A client certificate used to authenticate to kubernetes apiserver
@@ -560,6 +626,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -571,6 +639,8 @@ spec:
             sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total{job="apiserver"}[10m])) > 4
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -582,6 +652,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -592,6 +664,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -604,6 +678,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-kubelet
       rules:
         - alert: KubeNodeNotReady
@@ -616,6 +692,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -627,6 +705,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -644,6 +724,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -655,6 +737,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -666,6 +750,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -677,6 +763,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -687,6 +775,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -697,6 +787,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -707,6 +799,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -717,6 +811,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -728,6 +824,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -739,6 +837,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -749,6 +849,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-scheduler
       rules:
         - alert: KubeSchedulerDown
@@ -761,6 +863,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-controller-manager
       rules:
         - alert: KubeControllerManagerDown
@@ -774,6 +878,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-burnrate.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.26/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.26/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.27/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.27/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
         - alert: InfoInhibitor
           annotations:
             description: |
@@ -59,6 +63,8 @@ spec:
             == 1
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -73,6 +79,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/kubernetes_1.27/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.27/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: config-reloaders
       rules:
         - alert: ConfigReloaderSidecarErrors
@@ -110,3 +124,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.27/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.27/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusSDRefreshFailure
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -43,6 +45,8 @@ spec:
           for: 20m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -61,6 +65,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -80,6 +86,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -93,6 +101,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -104,6 +114,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -115,6 +127,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -134,6 +148,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -158,6 +176,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -180,6 +200,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -199,6 +221,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -220,6 +244,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -231,6 +257,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -256,6 +286,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -269,6 +301,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -281,6 +315,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -294,6 +330,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -305,6 +343,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusHighQueryLoad
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} query API
@@ -318,6 +358,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -337,3 +379,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.27/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.27/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -65,6 +69,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -83,6 +89,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -101,6 +109,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -116,6 +126,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -138,6 +150,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -160,3 +174,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.27/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
+++ b/tests/golden/kubernetes_1.27/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
@@ -25996,7 +25996,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26043,7 +26043,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26105,7 +26105,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26152,7 +26152,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26228,7 +26228,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26297,7 +26297,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26367,7 +26367,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26414,7 +26414,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26476,7 +26476,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26590,7 +26590,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26637,7 +26637,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26699,7 +26699,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26746,7 +26746,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26822,7 +26822,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26891,7 +26891,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26961,7 +26961,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27008,7 +27008,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27070,7 +27070,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27193,7 +27193,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27235,7 +27235,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27315,7 +27315,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27371,7 +27371,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27451,7 +27451,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27592,7 +27592,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27752,7 +27752,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27794,7 +27794,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27918,7 +27918,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27960,7 +27960,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28040,7 +28040,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28120,7 +28120,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28200,7 +28200,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28341,7 +28341,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28501,7 +28501,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28543,7 +28543,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28667,7 +28667,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28709,7 +28709,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28789,7 +28789,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28861,7 +28861,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28941,7 +28941,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -29082,7 +29082,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -29242,7 +29242,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -29284,7 +29284,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {

--- a/tests/golden/kubernetes_1.27/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.27/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: grafana_rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.27/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.27/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -72,6 +76,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -88,6 +94,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -107,6 +115,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -126,6 +136,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -142,6 +154,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -158,6 +172,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -170,6 +186,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -182,6 +200,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $labels.instance }} {{ $value | humanizePercentage }}
@@ -192,6 +212,8 @@ spec:
             (node_nf_conntrack_entries{job="nodeexporter-default-instance"} / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector on {{ $labels.instance
@@ -202,6 +224,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock at {{ $labels.instance }} is out of sync by more than
@@ -223,6 +247,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock at {{ $labels.instance }} is not synchronising. Ensure
@@ -236,6 +262,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' at {{ $labels.instance
@@ -248,6 +276,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array at {{ $labels.instance
@@ -259,6 +289,8 @@ spec:
             node_md_disks{state="failed",job="nodeexporter-default-instance",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -272,6 +304,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -285,6 +319,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeCPUHighUsage
           annotations:
             description: |
@@ -296,6 +332,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemSaturation
           annotations:
             description: |
@@ -309,6 +347,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryMajorPagesFaults
           annotations:
             description: |
@@ -321,6 +361,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryHighUtilization
           annotations:
             description: |
@@ -332,6 +374,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeDiskIOSaturation
           annotations:
             description: |
@@ -344,6 +388,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceFailed
           annotations:
             description: Systemd service {{ $labels.name }} has entered failed state
@@ -355,6 +401,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceCrashlooping
           annotations:
             description: Systemd service {{ $labels.name }} has being restarted too
@@ -367,6 +415,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeBondingDegraded
           annotations:
             description: Bonding interface {{ $labels.master }} on {{ $labels.instance
@@ -378,6 +428,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.27/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.27/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -27,6 +27,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -44,6 +46,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -58,6 +62,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -78,6 +84,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentRolloutStuck
           annotations:
             description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -90,6 +98,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -110,6 +120,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -124,6 +136,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -151,6 +165,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -184,6 +200,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeContainerWaiting
           annotations:
             description: pod/{{ $labels.pod }} in namespace {{ $labels.namespace }}
@@ -196,6 +214,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -209,6 +229,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -220,6 +242,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -232,6 +256,8 @@ spec:
             kube_job_status_active{job="kubestatemetrics-default-instance"} > 0) > 43200
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -244,6 +270,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -260,6 +288,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -274,6 +304,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeCPUQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted CPU resource
@@ -288,6 +320,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted memory resource
@@ -302,6 +336,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -316,6 +352,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -330,6 +368,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -344,6 +384,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp
@@ -368,6 +410,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -393,6 +437,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -415,6 +461,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -440,6 +488,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeErrors
           annotations:
             description: The persistent volume {{ $labels.persistentvolume }} has
@@ -451,6 +501,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system
       rules:
         - alert: KubeVersionMismatch
@@ -464,6 +516,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientErrors
           annotations:
             description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
@@ -478,6 +532,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-slos
       rules:
         - alert: KubeAPIErrorBudgetBurn
@@ -494,6 +550,8 @@ spec:
             long: 1h
             severity: critical
             short: 5m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -508,6 +566,8 @@ spec:
             long: 6h
             severity: critical
             short: 30m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -522,6 +582,8 @@ spec:
             long: 1d
             severity: warning
             short: 2h
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -536,6 +598,8 @@ spec:
             long: 3d
             severity: warning
             short: 6h
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-apiserver
       rules:
         - alert: KubeClientCertificateExpiration
@@ -549,6 +613,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientCertificateExpiration
           annotations:
             description: A client certificate used to authenticate to kubernetes apiserver
@@ -560,6 +626,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -571,6 +639,8 @@ spec:
             sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total{job="apiserver"}[10m])) > 4
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -582,6 +652,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -592,6 +664,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -604,6 +678,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-kubelet
       rules:
         - alert: KubeNodeNotReady
@@ -616,6 +692,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -627,6 +705,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -644,6 +724,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -655,6 +737,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -666,6 +750,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -677,6 +763,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -687,6 +775,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -697,6 +787,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -707,6 +799,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -717,6 +811,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -728,6 +824,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -739,6 +837,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -749,6 +849,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-scheduler
       rules:
         - alert: KubeSchedulerDown
@@ -761,6 +863,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-controller-manager
       rules:
         - alert: KubeControllerManagerDown
@@ -774,6 +878,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-burnrate.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.27/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.27/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.28/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.28/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
         - alert: InfoInhibitor
           annotations:
             description: |
@@ -59,6 +63,8 @@ spec:
             == 1
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -73,6 +79,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/kubernetes_1.28/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.28/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: config-reloaders
       rules:
         - alert: ConfigReloaderSidecarErrors
@@ -110,3 +124,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.28/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.28/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusSDRefreshFailure
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -43,6 +45,8 @@ spec:
           for: 20m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -61,6 +65,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -80,6 +86,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -93,6 +101,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -104,6 +114,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -115,6 +127,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -134,6 +148,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -158,6 +176,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -180,6 +200,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -199,6 +221,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -220,6 +244,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -231,6 +257,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -256,6 +286,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -269,6 +301,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -281,6 +315,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -294,6 +330,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -305,6 +343,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusHighQueryLoad
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} query API
@@ -318,6 +358,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -337,3 +379,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.28/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.28/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -65,6 +69,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -83,6 +89,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -101,6 +109,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -116,6 +126,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -138,6 +150,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -160,3 +174,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.28/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
+++ b/tests/golden/kubernetes_1.28/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
@@ -25996,7 +25996,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26043,7 +26043,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26105,7 +26105,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26152,7 +26152,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26228,7 +26228,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26297,7 +26297,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26367,7 +26367,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26414,7 +26414,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26476,7 +26476,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26590,7 +26590,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26637,7 +26637,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26699,7 +26699,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26746,7 +26746,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26822,7 +26822,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26891,7 +26891,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -26961,7 +26961,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27008,7 +27008,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27070,7 +27070,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27193,7 +27193,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27235,7 +27235,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27315,7 +27315,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27371,7 +27371,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27451,7 +27451,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27592,7 +27592,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27752,7 +27752,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27794,7 +27794,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27918,7 +27918,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -27960,7 +27960,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28040,7 +28040,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28120,7 +28120,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28200,7 +28200,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28341,7 +28341,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28501,7 +28501,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28543,7 +28543,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28667,7 +28667,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28709,7 +28709,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28789,7 +28789,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28861,7 +28861,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -28941,7 +28941,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -29082,7 +29082,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -29242,7 +29242,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -29284,7 +29284,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {

--- a/tests/golden/kubernetes_1.28/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.28/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: grafana_rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.28/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.28/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -72,6 +76,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -88,6 +94,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -107,6 +115,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -126,6 +136,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -142,6 +154,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -158,6 +172,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -170,6 +186,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -182,6 +200,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $labels.instance }} {{ $value | humanizePercentage }}
@@ -192,6 +212,8 @@ spec:
             (node_nf_conntrack_entries{job="nodeexporter-default-instance"} / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector on {{ $labels.instance
@@ -202,6 +224,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock at {{ $labels.instance }} is out of sync by more than
@@ -223,6 +247,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock at {{ $labels.instance }} is not synchronising. Ensure
@@ -236,6 +262,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' at {{ $labels.instance
@@ -248,6 +276,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array at {{ $labels.instance
@@ -259,6 +289,8 @@ spec:
             node_md_disks{state="failed",job="nodeexporter-default-instance",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -272,6 +304,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -285,6 +319,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeCPUHighUsage
           annotations:
             description: |
@@ -296,6 +332,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemSaturation
           annotations:
             description: |
@@ -309,6 +347,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryMajorPagesFaults
           annotations:
             description: |
@@ -321,6 +361,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryHighUtilization
           annotations:
             description: |
@@ -332,6 +374,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeDiskIOSaturation
           annotations:
             description: |
@@ -344,6 +388,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceFailed
           annotations:
             description: Systemd service {{ $labels.name }} has entered failed state
@@ -355,6 +401,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceCrashlooping
           annotations:
             description: Systemd service {{ $labels.name }} has being restarted too
@@ -367,6 +415,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeBondingDegraded
           annotations:
             description: Bonding interface {{ $labels.master }} on {{ $labels.instance
@@ -378,6 +428,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.28/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.28/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -27,6 +27,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -44,6 +46,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -58,6 +62,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -78,6 +84,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentRolloutStuck
           annotations:
             description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -90,6 +98,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -110,6 +120,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -124,6 +136,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -151,6 +165,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -184,6 +200,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeContainerWaiting
           annotations:
             description: pod/{{ $labels.pod }} in namespace {{ $labels.namespace }}
@@ -196,6 +214,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -209,6 +229,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -220,6 +242,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -232,6 +256,8 @@ spec:
             kube_job_status_active{job="kubestatemetrics-default-instance"} > 0) > 43200
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -244,6 +270,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -260,6 +288,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -274,6 +304,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeCPUQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted CPU resource
@@ -288,6 +320,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted memory resource
@@ -302,6 +336,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -316,6 +352,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -330,6 +368,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -344,6 +384,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp
@@ -368,6 +410,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -393,6 +437,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -415,6 +461,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -440,6 +488,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeErrors
           annotations:
             description: The persistent volume {{ $labels.persistentvolume }} has
@@ -451,6 +501,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system
       rules:
         - alert: KubeVersionMismatch
@@ -464,6 +516,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientErrors
           annotations:
             description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
@@ -478,6 +532,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-slos
       rules:
         - alert: KubeAPIErrorBudgetBurn
@@ -494,6 +550,8 @@ spec:
             long: 1h
             severity: critical
             short: 5m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -508,6 +566,8 @@ spec:
             long: 6h
             severity: critical
             short: 30m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -522,6 +582,8 @@ spec:
             long: 1d
             severity: warning
             short: 2h
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -536,6 +598,8 @@ spec:
             long: 3d
             severity: warning
             short: 6h
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-apiserver
       rules:
         - alert: KubeClientCertificateExpiration
@@ -549,6 +613,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientCertificateExpiration
           annotations:
             description: A client certificate used to authenticate to kubernetes apiserver
@@ -560,6 +626,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -571,6 +639,8 @@ spec:
             sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total{job="apiserver"}[10m])) > 4
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -582,6 +652,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -592,6 +664,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -604,6 +678,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-kubelet
       rules:
         - alert: KubeNodeNotReady
@@ -616,6 +692,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -627,6 +705,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -644,6 +724,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -655,6 +737,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -666,6 +750,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -677,6 +763,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -687,6 +775,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -697,6 +787,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -707,6 +799,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -717,6 +811,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -728,6 +824,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -739,6 +837,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -749,6 +849,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-scheduler
       rules:
         - alert: KubeSchedulerDown
@@ -761,6 +863,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-controller-manager
       rules:
         - alert: KubeControllerManagerDown
@@ -774,6 +878,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-burnrate.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.28/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.28/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.29/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.29/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
         - alert: InfoInhibitor
           annotations:
             description: |
@@ -59,6 +63,8 @@ spec:
             == 1
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -73,6 +79,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/kubernetes_1.29/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.29/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorStatusUpdateErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of status update operations
@@ -74,6 +82,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -85,6 +95,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -108,6 +122,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: config-reloaders
       rules:
         - alert: ConfigReloaderSidecarErrors
@@ -122,3 +138,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.29/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.29/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusSDRefreshFailure
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -43,6 +45,8 @@ spec:
           for: 20m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusKubernetesListWatchFailures
           annotations:
             description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -55,6 +59,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -73,6 +79,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -92,6 +100,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -105,6 +115,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -116,6 +128,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -127,6 +141,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -158,6 +176,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -170,6 +190,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -192,6 +214,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -211,6 +235,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -232,6 +258,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -255,6 +285,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -268,6 +300,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -281,6 +315,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -293,6 +329,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -306,6 +344,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -317,6 +357,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusHighQueryLoad
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} query API
@@ -330,6 +372,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -349,3 +393,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.29/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.29/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -65,6 +69,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -83,6 +89,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -101,6 +109,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -116,6 +126,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -138,6 +150,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -160,3 +174,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.29/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
+++ b/tests/golden/kubernetes_1.29/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
@@ -638,7 +638,7 @@ items:
                     "options": {
                         "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only."
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "title": "Notice",
                     "type": "text"
                 },
@@ -662,7 +662,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -708,7 +708,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -742,7 +742,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -840,7 +840,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -884,7 +884,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -927,7 +927,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -961,7 +961,7 @@ items:
                     },
                     "id": 8,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1059,7 +1059,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1103,7 +1103,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1146,7 +1146,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1189,7 +1189,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1232,7 +1232,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1278,7 +1278,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1320,7 +1320,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1363,7 +1363,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1405,7 +1405,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1536,7 +1536,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1582,7 +1582,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1653,7 +1653,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1818,7 +1818,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1864,7 +1864,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1910,7 +1910,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1956,7 +1956,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2002,7 +2002,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2048,7 +2048,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2094,7 +2094,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2140,7 +2140,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2186,7 +2186,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2232,7 +2232,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2339,7 +2339,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2390,7 +2390,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2441,7 +2441,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2492,7 +2492,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2543,7 +2543,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2618,7 +2618,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2669,7 +2669,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2720,7 +2720,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2771,7 +2771,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2822,7 +2822,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3567,7 +3567,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3602,7 +3602,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3637,7 +3637,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3672,7 +3672,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3707,7 +3707,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3742,7 +3742,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3792,7 +3792,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3851,7 +3851,7 @@ items:
                         "y": 12
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4008,7 +4008,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4103,7 +4103,7 @@ items:
                         "y": 24
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4280,7 +4280,7 @@ items:
                         "y": 30
                     },
                     "id": 11,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4424,7 +4424,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4475,7 +4475,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4526,7 +4526,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4577,7 +4577,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4628,7 +4628,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4679,7 +4679,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4730,7 +4730,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4781,7 +4781,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4832,7 +4832,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4883,7 +4883,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4954,7 +4954,7 @@ items:
                         "y": 96
                     },
                     "id": 22,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5154,7 +5154,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5189,7 +5189,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5224,7 +5224,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5259,7 +5259,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5294,7 +5294,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5329,7 +5329,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5374,7 +5374,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5433,7 +5433,7 @@ items:
                         "y": 2
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5559,7 +5559,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5621,7 +5621,7 @@ items:
                         "y": 4
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5795,7 +5795,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5830,7 +5830,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5865,7 +5865,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5900,7 +5900,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6002,7 +6002,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6077,7 +6077,7 @@ items:
                         "y": 14
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6260,7 +6260,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6338,7 +6338,7 @@ items:
                         "y": 28
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6528,7 +6528,7 @@ items:
                         "y": 35
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6672,7 +6672,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6723,7 +6723,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6774,7 +6774,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6825,7 +6825,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6876,7 +6876,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6927,7 +6927,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6978,7 +6978,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7029,7 +7029,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7100,7 +7100,7 @@ items:
                         "y": 70
                     },
                     "id": 18,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7372,7 +7372,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7439,7 +7439,7 @@ items:
                         "y": 6
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7601,7 +7601,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7671,7 +7671,7 @@ items:
                         "y": 18
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7958,7 +7958,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8064,7 +8064,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8106,7 +8106,7 @@ items:
                         "y": 14
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8289,7 +8289,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8350,7 +8350,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8520,7 +8520,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8571,7 +8571,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8622,7 +8622,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8673,7 +8673,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8724,7 +8724,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8775,7 +8775,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8826,7 +8826,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8885,7 +8885,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8944,7 +8944,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8995,7 +8995,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9049,7 +9049,7 @@ items:
                         "y": 70
                     },
                     "id": 16,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9290,7 +9290,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9349,7 +9349,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9480,7 +9480,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9542,7 +9542,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9693,7 +9693,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9837,7 +9837,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9888,7 +9888,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9939,7 +9939,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9990,7 +9990,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10041,7 +10041,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10092,7 +10092,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10143,7 +10143,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10194,7 +10194,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10408,7 +10408,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10495,7 +10495,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10703,7 +10703,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10793,7 +10793,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10969,7 +10969,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11113,7 +11113,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11164,7 +11164,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11215,7 +11215,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11266,7 +11266,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11317,7 +11317,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11368,7 +11368,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11419,7 +11419,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11470,7 +11470,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11604,7 +11604,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11639,7 +11639,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11674,7 +11674,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11709,7 +11709,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11744,7 +11744,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11779,7 +11779,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11830,7 +11830,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11881,7 +11881,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11932,7 +11932,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11983,7 +11983,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12042,7 +12042,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12101,7 +12101,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12152,7 +12152,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12203,7 +12203,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12254,7 +12254,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12305,7 +12305,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12356,7 +12356,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12407,7 +12407,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12458,7 +12458,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12509,7 +12509,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12584,7 +12584,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12635,7 +12635,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12686,7 +12686,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12737,7 +12737,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12875,7 +12875,7 @@ items:
                         "y": 0
                     },
                     "id": 1,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12928,7 +12928,7 @@ items:
                         "y": 0
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12999,7 +12999,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13138,7 +13138,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13184,7 +13184,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13230,7 +13230,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13276,7 +13276,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13322,7 +13322,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13368,7 +13368,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13499,7 +13499,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13538,7 +13538,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13609,7 +13609,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13795,7 +13795,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13846,7 +13846,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13897,7 +13897,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13948,7 +13948,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13999,7 +13999,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14050,7 +14050,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14101,7 +14101,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14152,7 +14152,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18605,7 +18605,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18667,7 +18667,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18717,7 +18717,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18779,7 +18779,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18930,7 +18930,7 @@ items:
                         "y": 0
                     },
                     "id": 1,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18983,7 +18983,7 @@ items:
                         "y": 0
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19029,7 +19029,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19075,7 +19075,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19121,7 +19121,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19167,7 +19167,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19213,7 +19213,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19259,7 +19259,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22304,7 +22304,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22355,7 +22355,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22406,7 +22406,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22457,7 +22457,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22508,7 +22508,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22559,7 +22559,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22634,7 +22634,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22685,7 +22685,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22736,7 +22736,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22787,7 +22787,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22838,7 +22838,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22959,7 +22959,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23010,7 +23010,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23085,7 +23085,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23160,7 +23160,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23235,7 +23235,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23286,7 +23286,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23337,7 +23337,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23388,7 +23388,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23439,7 +23439,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23564,7 +23564,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23603,7 +23603,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23642,7 +23642,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23681,7 +23681,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23732,7 +23732,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23783,7 +23783,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23834,7 +23834,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23885,7 +23885,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23936,7 +23936,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23987,7 +23987,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {

--- a/tests/golden/kubernetes_1.29/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.29/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: grafana_rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.29/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.29/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -72,6 +76,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -88,6 +94,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -107,6 +115,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -126,6 +136,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -142,6 +154,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -158,6 +172,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -170,6 +186,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -182,6 +200,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -192,6 +212,8 @@ spec:
             (node_nf_conntrack_entries{job="nodeexporter-default-instance"} / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector on {{ $labels.instance
@@ -202,6 +224,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock at {{ $labels.instance }} is out of sync by more than
@@ -223,6 +247,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock at {{ $labels.instance }} is not synchronising. Ensure
@@ -236,6 +262,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' at {{ $labels.instance
@@ -248,6 +276,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array at {{ $labels.instance
@@ -259,6 +289,8 @@ spec:
             node_md_disks{state="failed",job="nodeexporter-default-instance",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -272,6 +304,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -285,6 +319,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeCPUHighUsage
           annotations:
             description: |
@@ -296,6 +332,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemSaturation
           annotations:
             description: |
@@ -309,6 +347,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryMajorPagesFaults
           annotations:
             description: |
@@ -321,6 +361,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryHighUtilization
           annotations:
             description: |
@@ -332,6 +374,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeDiskIOSaturation
           annotations:
             description: |
@@ -344,6 +388,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceFailed
           annotations:
             description: Systemd service {{ $labels.name }} has entered failed state
@@ -355,6 +401,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeBondingDegraded
           annotations:
             description: Bonding interface {{ $labels.master }} on {{ $labels.instance
@@ -366,6 +414,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.29/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.29/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -27,6 +27,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -44,6 +46,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -58,6 +62,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -78,6 +84,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentRolloutStuck
           annotations:
             description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -90,6 +98,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -110,6 +120,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -124,6 +136,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -151,6 +165,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -184,6 +200,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeContainerWaiting
           annotations:
             description: pod/{{ $labels.pod }} in namespace {{ $labels.namespace }}
@@ -196,6 +214,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -209,6 +229,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -220,6 +242,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -232,6 +256,8 @@ spec:
             kube_job_status_active{job="kubestatemetrics-default-instance"} > 0) > 43200
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -244,6 +270,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -260,6 +288,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -274,6 +304,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeCPUQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted CPU resource
@@ -288,6 +320,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted memory resource
@@ -302,6 +336,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -316,6 +352,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -330,6 +368,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -344,6 +384,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp
@@ -369,6 +411,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -395,6 +439,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -418,6 +464,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -444,6 +492,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeErrors
           annotations:
             description: The persistent volume {{ $labels.persistentvolume }} {{ with
@@ -456,6 +506,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system
       rules:
         - alert: KubeVersionMismatch
@@ -469,6 +521,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientErrors
           annotations:
             description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
@@ -483,6 +537,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-slos
       rules:
         - alert: KubeAPIErrorBudgetBurn
@@ -499,6 +555,8 @@ spec:
             long: 1h
             severity: critical
             short: 5m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -513,6 +571,8 @@ spec:
             long: 6h
             severity: critical
             short: 30m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -527,6 +587,8 @@ spec:
             long: 1d
             severity: warning
             short: 2h
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -541,6 +603,8 @@ spec:
             long: 3d
             severity: warning
             short: 6h
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-apiserver
       rules:
         - alert: KubeClientCertificateExpiration
@@ -554,6 +618,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientCertificateExpiration
           annotations:
             description: A client certificate used to authenticate to kubernetes apiserver
@@ -565,6 +631,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -576,6 +644,8 @@ spec:
             sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total{job="apiserver"}[10m])) > 4
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -587,6 +657,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -597,6 +669,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -609,6 +683,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-kubelet
       rules:
         - alert: KubeNodeNotReady
@@ -621,6 +697,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -632,6 +710,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -649,6 +729,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -660,6 +742,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -671,6 +755,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -682,6 +768,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -692,6 +780,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -702,6 +792,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -712,6 +804,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -722,6 +816,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -733,6 +829,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -744,6 +842,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -754,6 +854,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-scheduler
       rules:
         - alert: KubeSchedulerDown
@@ -766,6 +868,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-controller-manager
       rules:
         - alert: KubeControllerManagerDown
@@ -779,6 +883,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - interval: 3m
       name: kube-apiserver-availability.rules
       rules:

--- a/tests/golden/kubernetes_1.29/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.29/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.30/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.30/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
         - alert: InfoInhibitor
           annotations:
             description: |
@@ -59,6 +63,8 @@ spec:
             == 1
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -73,6 +79,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/kubernetes_1.30/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.30/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorStatusUpdateErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of status update operations
@@ -74,6 +82,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -85,6 +95,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -108,6 +122,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: config-reloaders
       rules:
         - alert: ConfigReloaderSidecarErrors
@@ -122,3 +138,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.30/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.30/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusSDRefreshFailure
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -43,6 +45,8 @@ spec:
           for: 20m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusKubernetesListWatchFailures
           annotations:
             description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -55,6 +59,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -73,6 +79,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -92,6 +100,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -105,6 +115,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -116,6 +128,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -127,6 +141,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -158,6 +176,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -170,6 +190,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -192,6 +214,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -211,6 +235,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -232,6 +258,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -255,6 +285,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -268,6 +300,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -281,6 +315,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -293,6 +329,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -306,6 +344,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -317,6 +357,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusHighQueryLoad
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} query API
@@ -330,6 +372,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -349,3 +393,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.30/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.30/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -65,6 +69,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -83,6 +89,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -101,6 +109,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -116,6 +126,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -138,6 +150,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -160,3 +174,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.30/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
+++ b/tests/golden/kubernetes_1.30/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
@@ -638,7 +638,7 @@ items:
                     "options": {
                         "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only."
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "title": "Notice",
                     "type": "text"
                 },
@@ -662,7 +662,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -708,7 +708,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -742,7 +742,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -840,7 +840,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -884,7 +884,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -927,7 +927,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -961,7 +961,7 @@ items:
                     },
                     "id": 8,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1059,7 +1059,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1103,7 +1103,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1146,7 +1146,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1189,7 +1189,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1232,7 +1232,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1278,7 +1278,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1320,7 +1320,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1363,7 +1363,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1405,7 +1405,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1536,7 +1536,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1582,7 +1582,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1653,7 +1653,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1818,7 +1818,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1864,7 +1864,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1910,7 +1910,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1956,7 +1956,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2002,7 +2002,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2048,7 +2048,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2094,7 +2094,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2140,7 +2140,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2186,7 +2186,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2232,7 +2232,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2339,7 +2339,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2390,7 +2390,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2441,7 +2441,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2492,7 +2492,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2543,7 +2543,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2618,7 +2618,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2669,7 +2669,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2720,7 +2720,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2771,7 +2771,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2822,7 +2822,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3567,7 +3567,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3602,7 +3602,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3637,7 +3637,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3672,7 +3672,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3707,7 +3707,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3742,7 +3742,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3792,7 +3792,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3851,7 +3851,7 @@ items:
                         "y": 12
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4008,7 +4008,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4103,7 +4103,7 @@ items:
                         "y": 24
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4280,7 +4280,7 @@ items:
                         "y": 30
                     },
                     "id": 11,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4424,7 +4424,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4475,7 +4475,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4526,7 +4526,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4577,7 +4577,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4628,7 +4628,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4679,7 +4679,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4730,7 +4730,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4781,7 +4781,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4832,7 +4832,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4883,7 +4883,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4954,7 +4954,7 @@ items:
                         "y": 96
                     },
                     "id": 22,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5154,7 +5154,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5189,7 +5189,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5224,7 +5224,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5259,7 +5259,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5294,7 +5294,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5329,7 +5329,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5374,7 +5374,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5433,7 +5433,7 @@ items:
                         "y": 2
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5559,7 +5559,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5621,7 +5621,7 @@ items:
                         "y": 4
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5795,7 +5795,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5830,7 +5830,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5865,7 +5865,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5900,7 +5900,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6002,7 +6002,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6077,7 +6077,7 @@ items:
                         "y": 14
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6260,7 +6260,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6338,7 +6338,7 @@ items:
                         "y": 28
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6528,7 +6528,7 @@ items:
                         "y": 35
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6672,7 +6672,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6723,7 +6723,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6774,7 +6774,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6825,7 +6825,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6876,7 +6876,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6927,7 +6927,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6978,7 +6978,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7029,7 +7029,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7100,7 +7100,7 @@ items:
                         "y": 70
                     },
                     "id": 18,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7372,7 +7372,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7439,7 +7439,7 @@ items:
                         "y": 6
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7601,7 +7601,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7671,7 +7671,7 @@ items:
                         "y": 18
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7958,7 +7958,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8064,7 +8064,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8106,7 +8106,7 @@ items:
                         "y": 14
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8289,7 +8289,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8350,7 +8350,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8520,7 +8520,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8571,7 +8571,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8622,7 +8622,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8673,7 +8673,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8724,7 +8724,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8775,7 +8775,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8826,7 +8826,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8885,7 +8885,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8944,7 +8944,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8995,7 +8995,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9049,7 +9049,7 @@ items:
                         "y": 70
                     },
                     "id": 16,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9290,7 +9290,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9349,7 +9349,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9480,7 +9480,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9542,7 +9542,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9693,7 +9693,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9837,7 +9837,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9888,7 +9888,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9939,7 +9939,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9990,7 +9990,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10041,7 +10041,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10092,7 +10092,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10143,7 +10143,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10194,7 +10194,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10408,7 +10408,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10495,7 +10495,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10703,7 +10703,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10793,7 +10793,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10969,7 +10969,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11113,7 +11113,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11164,7 +11164,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11215,7 +11215,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11266,7 +11266,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11317,7 +11317,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11368,7 +11368,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11419,7 +11419,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11470,7 +11470,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11604,7 +11604,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11639,7 +11639,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11674,7 +11674,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11709,7 +11709,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11744,7 +11744,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11779,7 +11779,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11830,7 +11830,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11881,7 +11881,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11932,7 +11932,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11983,7 +11983,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12042,7 +12042,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12101,7 +12101,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12152,7 +12152,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12203,7 +12203,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12254,7 +12254,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12305,7 +12305,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12356,7 +12356,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12407,7 +12407,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12458,7 +12458,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12509,7 +12509,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12584,7 +12584,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12635,7 +12635,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12686,7 +12686,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12737,7 +12737,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12875,7 +12875,7 @@ items:
                         "y": 0
                     },
                     "id": 1,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12928,7 +12928,7 @@ items:
                         "y": 0
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12999,7 +12999,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13138,7 +13138,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13184,7 +13184,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13230,7 +13230,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13276,7 +13276,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13322,7 +13322,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13368,7 +13368,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13499,7 +13499,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13538,7 +13538,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13609,7 +13609,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13795,7 +13795,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13846,7 +13846,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13897,7 +13897,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13948,7 +13948,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13999,7 +13999,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14050,7 +14050,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14101,7 +14101,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14152,7 +14152,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18605,7 +18605,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18667,7 +18667,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18717,7 +18717,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18779,7 +18779,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18930,7 +18930,7 @@ items:
                         "y": 0
                     },
                     "id": 1,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18983,7 +18983,7 @@ items:
                         "y": 0
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19029,7 +19029,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19075,7 +19075,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19121,7 +19121,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19167,7 +19167,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19213,7 +19213,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19259,7 +19259,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22304,7 +22304,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22355,7 +22355,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22406,7 +22406,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22457,7 +22457,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22508,7 +22508,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22559,7 +22559,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22634,7 +22634,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22685,7 +22685,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22736,7 +22736,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22787,7 +22787,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22838,7 +22838,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22959,7 +22959,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23010,7 +23010,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23085,7 +23085,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23160,7 +23160,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23235,7 +23235,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23286,7 +23286,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23337,7 +23337,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23388,7 +23388,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23439,7 +23439,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23564,7 +23564,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23603,7 +23603,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23642,7 +23642,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23681,7 +23681,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23732,7 +23732,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23783,7 +23783,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23834,7 +23834,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23885,7 +23885,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23936,7 +23936,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23987,7 +23987,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {

--- a/tests/golden/kubernetes_1.30/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.30/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: grafana_rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.30/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.30/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -72,6 +76,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -88,6 +94,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -107,6 +115,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -126,6 +136,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -142,6 +154,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -158,6 +172,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -170,6 +186,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -182,6 +200,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -192,6 +212,8 @@ spec:
             (node_nf_conntrack_entries{job="nodeexporter-default-instance"} / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector on {{ $labels.instance
@@ -202,6 +224,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock at {{ $labels.instance }} is out of sync by more than
@@ -223,6 +247,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock at {{ $labels.instance }} is not synchronising. Ensure
@@ -236,6 +262,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' at {{ $labels.instance
@@ -248,6 +276,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array at {{ $labels.instance
@@ -259,6 +289,8 @@ spec:
             node_md_disks{state="failed",job="nodeexporter-default-instance",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -272,6 +304,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -285,6 +319,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeCPUHighUsage
           annotations:
             description: |
@@ -296,6 +332,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemSaturation
           annotations:
             description: |
@@ -309,6 +347,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryMajorPagesFaults
           annotations:
             description: |
@@ -321,6 +361,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryHighUtilization
           annotations:
             description: |
@@ -332,6 +374,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeDiskIOSaturation
           annotations:
             description: |
@@ -344,6 +388,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceFailed
           annotations:
             description: Systemd service {{ $labels.name }} has entered failed state
@@ -355,6 +401,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeBondingDegraded
           annotations:
             description: Bonding interface {{ $labels.master }} on {{ $labels.instance
@@ -366,6 +414,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.30/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.30/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -27,6 +27,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -44,6 +46,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -58,6 +62,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -78,6 +84,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentRolloutStuck
           annotations:
             description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -90,6 +98,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -110,6 +120,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -124,6 +136,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -151,6 +165,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -184,6 +200,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeContainerWaiting
           annotations:
             description: pod/{{ $labels.pod }} in namespace {{ $labels.namespace }}
@@ -196,6 +214,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -209,6 +229,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -220,6 +242,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -232,6 +256,8 @@ spec:
             kube_job_status_active{job="kubestatemetrics-default-instance"} > 0) > 43200
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -244,6 +270,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -260,6 +288,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -274,6 +304,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeCPUQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted CPU resource
@@ -288,6 +320,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted memory resource
@@ -302,6 +336,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -316,6 +352,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -330,6 +368,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -344,6 +384,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp
@@ -369,6 +411,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -395,6 +439,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -418,6 +464,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -444,6 +492,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeErrors
           annotations:
             description: The persistent volume {{ $labels.persistentvolume }} {{ with
@@ -456,6 +506,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system
       rules:
         - alert: KubeVersionMismatch
@@ -469,6 +521,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientErrors
           annotations:
             description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
@@ -483,6 +537,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-slos
       rules:
         - alert: KubeAPIErrorBudgetBurn
@@ -499,6 +555,8 @@ spec:
             long: 1h
             severity: critical
             short: 5m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -513,6 +571,8 @@ spec:
             long: 6h
             severity: critical
             short: 30m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -527,6 +587,8 @@ spec:
             long: 1d
             severity: warning
             short: 2h
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -541,6 +603,8 @@ spec:
             long: 3d
             severity: warning
             short: 6h
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-apiserver
       rules:
         - alert: KubeClientCertificateExpiration
@@ -554,6 +618,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientCertificateExpiration
           annotations:
             description: A client certificate used to authenticate to kubernetes apiserver
@@ -565,6 +631,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -576,6 +644,8 @@ spec:
             sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total{job="apiserver"}[10m])) > 4
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -587,6 +657,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -597,6 +669,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -609,6 +683,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-kubelet
       rules:
         - alert: KubeNodeNotReady
@@ -621,6 +697,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -632,6 +710,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -649,6 +729,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -660,6 +742,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -671,6 +755,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -682,6 +768,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -692,6 +780,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -702,6 +792,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -712,6 +804,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -722,6 +816,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -733,6 +829,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -744,6 +842,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -754,6 +854,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-scheduler
       rules:
         - alert: KubeSchedulerDown
@@ -766,6 +868,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-controller-manager
       rules:
         - alert: KubeControllerManagerDown
@@ -779,6 +883,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - interval: 3m
       name: kube-apiserver-availability.rules
       rules:

--- a/tests/golden/kubernetes_1.30/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.30/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.31/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.31/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
         - alert: InfoInhibitor
           annotations:
             description: |
@@ -59,6 +63,8 @@ spec:
             == 1
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -73,6 +79,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/kubernetes_1.31/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.31/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorStatusUpdateErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of status update operations
@@ -74,6 +82,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -85,6 +95,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -108,6 +122,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: config-reloaders
       rules:
         - alert: ConfigReloaderSidecarErrors
@@ -122,3 +138,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.31/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.31/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusSDRefreshFailure
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -43,6 +45,8 @@ spec:
           for: 20m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusKubernetesListWatchFailures
           annotations:
             description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -55,6 +59,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -73,6 +79,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -92,6 +100,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -105,6 +115,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -116,6 +128,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -127,6 +141,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -158,6 +176,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -170,6 +190,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -192,6 +214,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -211,6 +235,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -232,6 +258,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -255,6 +285,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -268,6 +300,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -281,6 +315,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -293,6 +329,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -306,6 +344,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -317,6 +357,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusHighQueryLoad
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} query API
@@ -330,6 +372,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -349,3 +393,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.31/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.31/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -65,6 +69,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -83,6 +89,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -101,6 +109,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -116,6 +126,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -138,6 +150,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -160,3 +174,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.31/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
+++ b/tests/golden/kubernetes_1.31/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
@@ -638,7 +638,7 @@ items:
                     "options": {
                         "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only."
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "title": "Notice",
                     "type": "text"
                 },
@@ -662,7 +662,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -708,7 +708,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -742,7 +742,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -840,7 +840,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -884,7 +884,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -927,7 +927,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -961,7 +961,7 @@ items:
                     },
                     "id": 8,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1059,7 +1059,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1103,7 +1103,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1146,7 +1146,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1189,7 +1189,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1232,7 +1232,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1278,7 +1278,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1320,7 +1320,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1363,7 +1363,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1405,7 +1405,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1536,7 +1536,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1582,7 +1582,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1653,7 +1653,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1818,7 +1818,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1864,7 +1864,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1910,7 +1910,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1956,7 +1956,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2002,7 +2002,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2048,7 +2048,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2094,7 +2094,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2140,7 +2140,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2186,7 +2186,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2232,7 +2232,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2339,7 +2339,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2390,7 +2390,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2441,7 +2441,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2492,7 +2492,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2543,7 +2543,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2618,7 +2618,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2669,7 +2669,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2720,7 +2720,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2771,7 +2771,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2822,7 +2822,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3567,7 +3567,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3602,7 +3602,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3637,7 +3637,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3672,7 +3672,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3707,7 +3707,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3742,7 +3742,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3792,7 +3792,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3851,7 +3851,7 @@ items:
                         "y": 12
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4008,7 +4008,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4103,7 +4103,7 @@ items:
                         "y": 24
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4280,7 +4280,7 @@ items:
                         "y": 30
                     },
                     "id": 11,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4424,7 +4424,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4475,7 +4475,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4526,7 +4526,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4577,7 +4577,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4628,7 +4628,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4679,7 +4679,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4730,7 +4730,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4781,7 +4781,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4832,7 +4832,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4883,7 +4883,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4954,7 +4954,7 @@ items:
                         "y": 96
                     },
                     "id": 22,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5154,7 +5154,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5189,7 +5189,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5224,7 +5224,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5259,7 +5259,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5294,7 +5294,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5329,7 +5329,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5374,7 +5374,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5433,7 +5433,7 @@ items:
                         "y": 2
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5559,7 +5559,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5621,7 +5621,7 @@ items:
                         "y": 4
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5795,7 +5795,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5830,7 +5830,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5865,7 +5865,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5900,7 +5900,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6002,7 +6002,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6077,7 +6077,7 @@ items:
                         "y": 14
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6260,7 +6260,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6338,7 +6338,7 @@ items:
                         "y": 28
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6528,7 +6528,7 @@ items:
                         "y": 35
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6672,7 +6672,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6723,7 +6723,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6774,7 +6774,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6825,7 +6825,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6876,7 +6876,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6927,7 +6927,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6978,7 +6978,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7029,7 +7029,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7100,7 +7100,7 @@ items:
                         "y": 70
                     },
                     "id": 18,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7372,7 +7372,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7439,7 +7439,7 @@ items:
                         "y": 6
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7601,7 +7601,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7671,7 +7671,7 @@ items:
                         "y": 18
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7958,7 +7958,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8064,7 +8064,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8106,7 +8106,7 @@ items:
                         "y": 14
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8289,7 +8289,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8350,7 +8350,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8520,7 +8520,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8571,7 +8571,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8622,7 +8622,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8673,7 +8673,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8724,7 +8724,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8775,7 +8775,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8826,7 +8826,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8885,7 +8885,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8944,7 +8944,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8995,7 +8995,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9049,7 +9049,7 @@ items:
                         "y": 70
                     },
                     "id": 16,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9290,7 +9290,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9349,7 +9349,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9480,7 +9480,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9542,7 +9542,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9693,7 +9693,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9837,7 +9837,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9888,7 +9888,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9939,7 +9939,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9990,7 +9990,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10041,7 +10041,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10092,7 +10092,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10143,7 +10143,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10194,7 +10194,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10408,7 +10408,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10495,7 +10495,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10703,7 +10703,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10793,7 +10793,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10969,7 +10969,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11113,7 +11113,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11164,7 +11164,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11215,7 +11215,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11266,7 +11266,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11317,7 +11317,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11368,7 +11368,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11419,7 +11419,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11470,7 +11470,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11604,7 +11604,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11639,7 +11639,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11674,7 +11674,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11709,7 +11709,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11744,7 +11744,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11779,7 +11779,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11830,7 +11830,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11881,7 +11881,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11932,7 +11932,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11983,7 +11983,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12042,7 +12042,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12101,7 +12101,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12152,7 +12152,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12203,7 +12203,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12254,7 +12254,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12305,7 +12305,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12356,7 +12356,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12407,7 +12407,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12458,7 +12458,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12509,7 +12509,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12584,7 +12584,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12635,7 +12635,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12686,7 +12686,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12737,7 +12737,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12875,7 +12875,7 @@ items:
                         "y": 0
                     },
                     "id": 1,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12928,7 +12928,7 @@ items:
                         "y": 0
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12999,7 +12999,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13138,7 +13138,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13184,7 +13184,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13230,7 +13230,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13276,7 +13276,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13322,7 +13322,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13368,7 +13368,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13499,7 +13499,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13538,7 +13538,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13609,7 +13609,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13795,7 +13795,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13846,7 +13846,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13897,7 +13897,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13948,7 +13948,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13999,7 +13999,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14050,7 +14050,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14101,7 +14101,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14152,7 +14152,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18605,7 +18605,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18667,7 +18667,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18717,7 +18717,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18779,7 +18779,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18930,7 +18930,7 @@ items:
                         "y": 0
                     },
                     "id": 1,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18983,7 +18983,7 @@ items:
                         "y": 0
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19029,7 +19029,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19075,7 +19075,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19121,7 +19121,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19167,7 +19167,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19213,7 +19213,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19259,7 +19259,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22304,7 +22304,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22355,7 +22355,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22406,7 +22406,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22457,7 +22457,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22508,7 +22508,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22559,7 +22559,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22634,7 +22634,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22685,7 +22685,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22736,7 +22736,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22787,7 +22787,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22838,7 +22838,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22959,7 +22959,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23010,7 +23010,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23085,7 +23085,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23160,7 +23160,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23235,7 +23235,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23286,7 +23286,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23337,7 +23337,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23388,7 +23388,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23439,7 +23439,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23564,7 +23564,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23603,7 +23603,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23642,7 +23642,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23681,7 +23681,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23732,7 +23732,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23783,7 +23783,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23834,7 +23834,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23885,7 +23885,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23936,7 +23936,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23987,7 +23987,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {

--- a/tests/golden/kubernetes_1.31/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.31/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: grafana_rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.31/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.31/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -72,6 +76,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -88,6 +94,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -107,6 +115,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -126,6 +136,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -142,6 +154,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -158,6 +172,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -170,6 +186,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -182,6 +200,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -192,6 +212,8 @@ spec:
             (node_nf_conntrack_entries{job="nodeexporter-default-instance"} / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector on {{ $labels.instance
@@ -202,6 +224,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock at {{ $labels.instance }} is out of sync by more than
@@ -223,6 +247,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock at {{ $labels.instance }} is not synchronising. Ensure
@@ -236,6 +262,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' at {{ $labels.instance
@@ -248,6 +276,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array at {{ $labels.instance
@@ -259,6 +289,8 @@ spec:
             node_md_disks{state="failed",job="nodeexporter-default-instance",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -272,6 +304,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -285,6 +319,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeCPUHighUsage
           annotations:
             description: |
@@ -296,6 +332,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemSaturation
           annotations:
             description: |
@@ -309,6 +347,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryMajorPagesFaults
           annotations:
             description: |
@@ -321,6 +361,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryHighUtilization
           annotations:
             description: |
@@ -332,6 +374,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeDiskIOSaturation
           annotations:
             description: |
@@ -344,6 +388,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceFailed
           annotations:
             description: Systemd service {{ $labels.name }} has entered failed state
@@ -355,6 +401,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeBondingDegraded
           annotations:
             description: Bonding interface {{ $labels.master }} on {{ $labels.instance
@@ -366,6 +414,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.31/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.31/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -27,6 +27,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -44,6 +46,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -58,6 +62,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -78,6 +84,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentRolloutStuck
           annotations:
             description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -90,6 +98,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -110,6 +120,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -124,6 +136,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -151,6 +165,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -184,6 +200,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeContainerWaiting
           annotations:
             description: pod/{{ $labels.pod }} in namespace {{ $labels.namespace }}
@@ -196,6 +214,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -209,6 +229,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -220,6 +242,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -232,6 +256,8 @@ spec:
             kube_job_status_active{job="kubestatemetrics-default-instance"} > 0) > 43200
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -244,6 +270,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -260,6 +288,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -274,6 +304,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeCPUQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted CPU resource
@@ -288,6 +320,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted memory resource
@@ -302,6 +336,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -316,6 +352,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -330,6 +368,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -344,6 +384,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp
@@ -369,6 +411,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -395,6 +439,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -418,6 +464,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -444,6 +492,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeErrors
           annotations:
             description: The persistent volume {{ $labels.persistentvolume }} {{ with
@@ -456,6 +506,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system
       rules:
         - alert: KubeVersionMismatch
@@ -469,6 +521,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientErrors
           annotations:
             description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
@@ -483,6 +537,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-slos
       rules:
         - alert: KubeAPIErrorBudgetBurn
@@ -499,6 +555,8 @@ spec:
             long: 1h
             severity: critical
             short: 5m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -513,6 +571,8 @@ spec:
             long: 6h
             severity: critical
             short: 30m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -527,6 +587,8 @@ spec:
             long: 1d
             severity: warning
             short: 2h
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -541,6 +603,8 @@ spec:
             long: 3d
             severity: warning
             short: 6h
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-apiserver
       rules:
         - alert: KubeClientCertificateExpiration
@@ -554,6 +618,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientCertificateExpiration
           annotations:
             description: A client certificate used to authenticate to kubernetes apiserver
@@ -565,6 +631,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -576,6 +644,8 @@ spec:
             sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total{job="apiserver"}[10m])) > 4
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -587,6 +657,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -597,6 +669,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -609,6 +683,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-kubelet
       rules:
         - alert: KubeNodeNotReady
@@ -621,6 +697,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -632,6 +710,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -649,6 +729,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -660,6 +742,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -671,6 +755,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -682,6 +768,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -692,6 +780,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -702,6 +792,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -712,6 +804,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -722,6 +816,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -733,6 +829,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -744,6 +842,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -754,6 +854,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-scheduler
       rules:
         - alert: KubeSchedulerDown
@@ -766,6 +868,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-controller-manager
       rules:
         - alert: KubeControllerManagerDown
@@ -779,6 +883,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - interval: 3m
       name: kube-apiserver-availability.rules
       rules:

--- a/tests/golden/kubernetes_1.31/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.31/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.32/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.32/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
         - alert: InfoInhibitor
           annotations:
             description: |
@@ -59,6 +63,8 @@ spec:
             == 1
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -73,6 +79,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/kubernetes_1.32/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.32/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorStatusUpdateErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of status update operations
@@ -74,6 +82,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -85,6 +95,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -108,6 +122,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: config-reloaders
       rules:
         - alert: ConfigReloaderSidecarErrors
@@ -122,3 +138,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.32/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.32/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusSDRefreshFailure
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -43,6 +45,8 @@ spec:
           for: 20m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusKubernetesListWatchFailures
           annotations:
             description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -55,6 +59,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -73,6 +79,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% of alerts sent by Prometheus
@@ -92,6 +100,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -105,6 +115,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -116,6 +128,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -127,6 +141,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -158,6 +176,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -170,6 +190,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -192,6 +214,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -211,6 +235,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -232,6 +258,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -255,6 +285,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -268,6 +300,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -281,6 +315,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -293,6 +329,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -306,6 +344,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -317,6 +357,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusHighQueryLoad
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} query API
@@ -330,6 +372,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -349,3 +393,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.32/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.32/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -65,6 +69,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -83,6 +89,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -101,6 +109,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -116,6 +126,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -138,6 +150,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -160,3 +174,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.32/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
+++ b/tests/golden/kubernetes_1.32/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
@@ -54,7 +54,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -102,7 +102,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -174,7 +174,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "repeat": "integration",
                     "targets": [
                         {
@@ -232,7 +232,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "repeat": "integration",
                     "targets": [
                         {
@@ -398,7 +398,7 @@ items:
                     "options": {
                         "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only."
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "title": "Notice",
                     "type": "text"
                 },
@@ -422,7 +422,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -468,7 +468,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -502,7 +502,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -600,7 +600,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -644,7 +644,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -687,7 +687,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -721,7 +721,7 @@ items:
                     },
                     "id": 8,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -819,7 +819,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -863,7 +863,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -906,7 +906,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -949,7 +949,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -992,7 +992,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1038,7 +1038,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1080,7 +1080,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1123,7 +1123,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1165,7 +1165,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1296,7 +1296,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1342,7 +1342,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1413,7 +1413,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1578,7 +1578,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1624,7 +1624,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1670,7 +1670,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1716,7 +1716,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1762,7 +1762,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1808,7 +1808,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1854,7 +1854,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1900,7 +1900,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1946,7 +1946,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1992,7 +1992,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2099,7 +2099,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2150,7 +2150,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2201,7 +2201,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2252,7 +2252,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2303,7 +2303,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2378,7 +2378,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2429,7 +2429,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2480,7 +2480,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2531,7 +2531,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2582,7 +2582,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3327,7 +3327,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3362,7 +3362,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3397,7 +3397,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3432,7 +3432,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3467,7 +3467,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3502,7 +3502,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3552,7 +3552,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3611,7 +3611,7 @@ items:
                         "y": 12
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3768,7 +3768,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3863,7 +3863,7 @@ items:
                         "y": 24
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4040,7 +4040,7 @@ items:
                         "y": 30
                     },
                     "id": 11,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4184,7 +4184,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4235,7 +4235,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4286,7 +4286,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4337,7 +4337,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4388,7 +4388,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4439,7 +4439,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4490,7 +4490,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4541,7 +4541,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4592,7 +4592,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4643,7 +4643,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4714,7 +4714,7 @@ items:
                         "y": 96
                     },
                     "id": 22,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4914,7 +4914,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4949,7 +4949,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4984,7 +4984,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5019,7 +5019,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5054,7 +5054,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5089,7 +5089,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5134,7 +5134,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5193,7 +5193,7 @@ items:
                         "y": 2
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5319,7 +5319,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5381,7 +5381,7 @@ items:
                         "y": 4
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5555,7 +5555,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5590,7 +5590,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5625,7 +5625,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5660,7 +5660,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5762,7 +5762,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5837,7 +5837,7 @@ items:
                         "y": 14
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6020,7 +6020,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6098,7 +6098,7 @@ items:
                         "y": 28
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6288,7 +6288,7 @@ items:
                         "y": 35
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6432,7 +6432,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6483,7 +6483,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6534,7 +6534,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6585,7 +6585,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6636,7 +6636,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6687,7 +6687,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6738,7 +6738,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6789,7 +6789,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6860,7 +6860,7 @@ items:
                         "y": 70
                     },
                     "id": 18,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7132,7 +7132,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7199,7 +7199,7 @@ items:
                         "y": 6
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7361,7 +7361,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7464,7 +7464,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7534,7 +7534,7 @@ items:
                         "y": 24
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7821,7 +7821,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7927,7 +7927,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7969,7 +7969,7 @@ items:
                         "y": 14
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8152,7 +8152,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8213,7 +8213,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8383,7 +8383,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8434,7 +8434,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8485,7 +8485,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8536,7 +8536,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8587,7 +8587,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8638,7 +8638,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8689,7 +8689,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8748,7 +8748,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8807,7 +8807,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8858,7 +8858,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8912,7 +8912,7 @@ items:
                         "y": 70
                     },
                     "id": 16,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9125,7 +9125,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9160,7 +9160,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9195,7 +9195,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9230,7 +9230,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9265,7 +9265,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9300,7 +9300,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9350,7 +9350,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9409,7 +9409,7 @@ items:
                         "y": 14
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9540,7 +9540,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9638,7 +9638,7 @@ items:
                         "y": 28
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9827,7 +9827,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9886,7 +9886,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10017,7 +10017,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10079,7 +10079,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10281,7 +10281,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10340,7 +10340,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10471,7 +10471,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10516,7 +10516,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10647,7 +10647,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10803,7 +10803,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10862,7 +10862,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10993,7 +10993,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11055,7 +11055,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11206,7 +11206,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11350,7 +11350,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11401,7 +11401,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11452,7 +11452,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11503,7 +11503,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11554,7 +11554,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11605,7 +11605,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11656,7 +11656,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11707,7 +11707,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11921,7 +11921,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12008,7 +12008,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12216,7 +12216,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12306,7 +12306,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12482,7 +12482,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12626,7 +12626,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12677,7 +12677,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12728,7 +12728,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12779,7 +12779,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12830,7 +12830,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12881,7 +12881,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12932,7 +12932,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12983,7 +12983,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13120,7 +13120,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13171,7 +13171,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13222,7 +13222,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13273,7 +13273,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13324,7 +13324,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13375,7 +13375,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13426,7 +13426,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13536,7 +13536,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13587,7 +13587,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13638,7 +13638,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13689,7 +13689,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13756,7 +13756,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13807,7 +13807,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13872,7 +13872,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13939,7 +13939,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13990,7 +13990,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14041,7 +14041,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14160,7 +14160,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14195,7 +14195,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14230,7 +14230,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14265,7 +14265,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14300,7 +14300,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14335,7 +14335,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14386,7 +14386,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14437,7 +14437,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14488,7 +14488,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14539,7 +14539,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14598,7 +14598,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14657,7 +14657,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14708,7 +14708,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14759,7 +14759,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14810,7 +14810,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14861,7 +14861,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14912,7 +14912,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14963,7 +14963,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15014,7 +15014,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15065,7 +15065,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15140,7 +15140,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15191,7 +15191,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15242,7 +15242,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15293,7 +15293,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15432,7 +15432,7 @@ items:
                     },
                     "id": 1,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15486,7 +15486,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15557,7 +15557,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15696,7 +15696,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15742,7 +15742,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15788,7 +15788,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15834,7 +15834,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15880,7 +15880,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15926,7 +15926,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16058,7 +16058,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16098,7 +16098,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16169,7 +16169,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16355,7 +16355,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16406,7 +16406,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16457,7 +16457,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16508,7 +16508,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16559,7 +16559,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16610,7 +16610,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16661,7 +16661,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16712,7 +16712,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16865,7 +16865,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16912,7 +16912,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16974,7 +16974,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17021,7 +17021,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17097,7 +17097,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17166,7 +17166,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17236,7 +17236,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17283,7 +17283,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17345,7 +17345,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17466,7 +17466,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17513,7 +17513,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17575,7 +17575,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17622,7 +17622,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17698,7 +17698,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17767,7 +17767,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17837,7 +17837,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17884,7 +17884,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17946,7 +17946,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18068,7 +18068,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18110,7 +18110,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18190,7 +18190,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18246,7 +18246,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18326,7 +18326,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18467,7 +18467,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18627,7 +18627,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18669,7 +18669,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18791,7 +18791,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18833,7 +18833,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18913,7 +18913,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18993,7 +18993,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19073,7 +19073,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19214,7 +19214,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19374,7 +19374,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19416,7 +19416,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19538,7 +19538,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19580,7 +19580,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19660,7 +19660,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19732,7 +19732,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19812,7 +19812,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19953,7 +19953,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20113,7 +20113,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20155,7 +20155,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20280,7 +20280,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20342,7 +20342,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20392,7 +20392,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20454,7 +20454,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20606,7 +20606,7 @@ items:
                     },
                     "id": 1,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20660,7 +20660,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20706,7 +20706,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20752,7 +20752,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20798,7 +20798,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20844,7 +20844,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20890,7 +20890,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20936,7 +20936,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21087,7 +21087,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21129,7 +21129,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21186,7 +21186,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21243,7 +21243,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21285,7 +21285,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21327,7 +21327,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21369,7 +21369,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21426,7 +21426,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21468,7 +21468,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21525,7 +21525,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21567,7 +21567,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21623,7 +21623,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21664,7 +21664,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21705,7 +21705,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21746,7 +21746,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22047,7 +22047,7 @@ items:
                         "y": 1
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22116,7 +22116,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22163,7 +22163,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22221,7 +22221,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22268,7 +22268,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22351,7 +22351,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22413,7 +22413,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22460,7 +22460,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22522,7 +22522,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22569,7 +22569,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22721,7 +22721,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22772,7 +22772,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22823,7 +22823,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22874,7 +22874,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22925,7 +22925,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22976,7 +22976,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23051,7 +23051,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23102,7 +23102,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23153,7 +23153,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23204,7 +23204,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23255,7 +23255,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23376,7 +23376,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23427,7 +23427,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23502,7 +23502,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23577,7 +23577,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23652,7 +23652,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23703,7 +23703,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23754,7 +23754,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23805,7 +23805,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23856,7 +23856,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23982,7 +23982,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24022,7 +24022,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24062,7 +24062,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24102,7 +24102,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24153,7 +24153,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24204,7 +24204,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24255,7 +24255,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24306,7 +24306,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24357,7 +24357,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24408,7 +24408,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {

--- a/tests/golden/kubernetes_1.32/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.32/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: grafana_rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.32/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.32/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -72,6 +76,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -88,6 +94,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -107,6 +115,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -126,6 +136,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -142,6 +154,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -158,6 +172,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -170,6 +186,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -182,6 +200,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $labels.instance }} {{ $value | humanizePercentage }}
@@ -192,6 +212,8 @@ spec:
             (node_nf_conntrack_entries{job="nodeexporter-default-instance"} / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector on {{ $labels.instance
@@ -202,6 +224,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock at {{ $labels.instance }} is out of sync by more than
@@ -223,6 +247,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock at {{ $labels.instance }} is not synchronising. Ensure
@@ -236,6 +262,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' at {{ $labels.instance
@@ -248,6 +276,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array at {{ $labels.instance
@@ -259,6 +289,8 @@ spec:
             node_md_disks{state="failed",job="nodeexporter-default-instance",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -272,6 +304,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -285,6 +319,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeCPUHighUsage
           annotations:
             description: |
@@ -296,6 +332,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemSaturation
           annotations:
             description: |
@@ -309,6 +347,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryMajorPagesFaults
           annotations:
             description: |
@@ -321,6 +361,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryHighUtilization
           annotations:
             description: |
@@ -332,6 +374,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeDiskIOSaturation
           annotations:
             description: |
@@ -344,6 +388,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceFailed
           annotations:
             description: Systemd service {{ $labels.name }} has entered failed state
@@ -355,6 +401,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceCrashlooping
           annotations:
             description: Systemd service {{ $labels.name }} has being restarted too
@@ -367,6 +415,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeBondingDegraded
           annotations:
             description: Bonding interface {{ $labels.master }} on {{ $labels.instance
@@ -378,6 +428,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.32/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.32/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -46,6 +48,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -80,6 +86,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentRolloutStuck
           annotations:
             description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -93,6 +101,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -113,6 +123,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -127,6 +139,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -154,6 +168,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -188,6 +204,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeContainerWaiting
           annotations:
             description: 'pod/{{ $labels.pod }} in namespace {{ $labels.namespace
@@ -201,6 +219,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -215,6 +235,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -227,6 +249,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -240,6 +264,8 @@ spec:
             kube_job_status_active{job="kubestatemetrics-default-instance"} > 0) > 43200
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -252,6 +278,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePdbNotEnoughHealthyPods
           annotations:
             description: PDB {{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.poddisruptionbudget
@@ -269,6 +297,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -285,6 +315,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -299,6 +331,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeCPUQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted CPU resource
@@ -313,6 +347,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -327,6 +363,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -342,6 +380,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -357,6 +397,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -372,6 +414,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp
@@ -397,6 +441,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -423,6 +469,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -446,6 +494,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -472,6 +522,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeErrors
           annotations:
             description: The persistent volume {{ $labels.persistentvolume }} {{ with
@@ -484,6 +536,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system
       rules:
         - alert: KubeVersionMismatch
@@ -497,6 +551,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientErrors
           annotations:
             description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
@@ -512,6 +568,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-slos
       rules:
         - alert: KubeAPIErrorBudgetBurn
@@ -529,6 +587,8 @@ spec:
             long: 1h
             severity: critical
             short: 5m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -544,6 +604,8 @@ spec:
             long: 6h
             severity: critical
             short: 30m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -559,6 +621,8 @@ spec:
             long: 1d
             severity: warning
             short: 2h
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -574,6 +638,8 @@ spec:
             long: 3d
             severity: warning
             short: 6h
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-apiserver
       rules:
         - alert: KubeClientCertificateExpiration
@@ -589,6 +655,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientCertificateExpiration
           annotations:
             description: A client certificate used to authenticate to kubernetes apiserver
@@ -602,6 +670,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.instance }}/{{ $labels.name
@@ -614,6 +684,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -626,6 +698,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -636,6 +710,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -648,6 +724,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-kubelet
       rules:
         - alert: KubeNodeNotReady
@@ -663,6 +741,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodePressure
           annotations:
             description: '{{ $labels.node }} on cluster {{ $labels.cluster }} has
@@ -677,6 +757,8 @@ spec:
           for: 10m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -688,6 +770,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -711,6 +795,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -725,6 +811,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeEviction
           annotations:
             description: Node {{ $labels.node }} on {{ $labels.cluster }} is evicting
@@ -743,6 +831,8 @@ spec:
           for: 0s
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -755,6 +845,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -767,6 +859,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -778,6 +872,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -789,6 +885,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -800,6 +898,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -811,6 +911,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -823,6 +925,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -835,6 +939,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -845,6 +951,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-scheduler
       rules:
         - alert: KubeSchedulerDown
@@ -857,6 +965,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-controller-manager
       rules:
         - alert: KubeControllerManagerDown
@@ -870,6 +980,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - interval: 3m
       name: kube-apiserver-availability.rules
       rules:

--- a/tests/golden/kubernetes_1.32/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.32/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.33/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.33/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
         - alert: InfoInhibitor
           annotations:
             description: |
@@ -59,6 +63,8 @@ spec:
             == 1
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -73,6 +79,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/kubernetes_1.33/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.33/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorStatusUpdateErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of status update operations
@@ -74,6 +82,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -85,6 +95,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -108,6 +122,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: config-reloaders
       rules:
         - alert: ConfigReloaderSidecarErrors
@@ -122,3 +138,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.33/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.33/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusSDRefreshFailure
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -43,6 +45,8 @@ spec:
           for: 20m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusKubernetesListWatchFailures
           annotations:
             description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -55,6 +59,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -73,6 +79,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% of alerts sent by Prometheus
@@ -92,6 +100,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -105,6 +115,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -116,6 +128,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -127,6 +141,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -158,6 +176,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -170,6 +190,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -192,6 +214,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -211,6 +235,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -232,6 +258,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -255,6 +285,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -268,6 +300,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -281,6 +315,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -293,6 +329,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -306,6 +344,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -317,6 +357,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusHighQueryLoad
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} query API
@@ -330,6 +372,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -349,3 +393,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.33/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.33/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -65,6 +69,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -83,6 +89,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -101,6 +109,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -116,6 +126,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -138,6 +150,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -160,3 +174,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.33/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
+++ b/tests/golden/kubernetes_1.33/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
@@ -54,7 +54,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -102,7 +102,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -174,7 +174,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "repeat": "integration",
                     "targets": [
                         {
@@ -232,7 +232,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "repeat": "integration",
                     "targets": [
                         {
@@ -398,7 +398,7 @@ items:
                     "options": {
                         "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only."
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "title": "Notice",
                     "type": "text"
                 },
@@ -422,7 +422,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -468,7 +468,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -502,7 +502,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -600,7 +600,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -644,7 +644,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -687,7 +687,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -721,7 +721,7 @@ items:
                     },
                     "id": 8,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -819,7 +819,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -863,7 +863,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -906,7 +906,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -949,7 +949,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -992,7 +992,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1038,7 +1038,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1080,7 +1080,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1123,7 +1123,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1165,7 +1165,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1296,7 +1296,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1342,7 +1342,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1413,7 +1413,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1578,7 +1578,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1624,7 +1624,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1670,7 +1670,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1716,7 +1716,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1762,7 +1762,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1808,7 +1808,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1854,7 +1854,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1900,7 +1900,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1946,7 +1946,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1992,7 +1992,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2099,7 +2099,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2150,7 +2150,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2201,7 +2201,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2252,7 +2252,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2303,7 +2303,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2378,7 +2378,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2429,7 +2429,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2480,7 +2480,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2531,7 +2531,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2582,7 +2582,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3327,7 +3327,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3362,7 +3362,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3397,7 +3397,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3432,7 +3432,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3467,7 +3467,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3502,7 +3502,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3552,7 +3552,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3611,7 +3611,7 @@ items:
                         "y": 12
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3768,7 +3768,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3863,7 +3863,7 @@ items:
                         "y": 24
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4040,7 +4040,7 @@ items:
                         "y": 30
                     },
                     "id": 11,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4184,7 +4184,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4235,7 +4235,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4286,7 +4286,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4337,7 +4337,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4388,7 +4388,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4439,7 +4439,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4490,7 +4490,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4541,7 +4541,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4592,7 +4592,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4643,7 +4643,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4714,7 +4714,7 @@ items:
                         "y": 96
                     },
                     "id": 22,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4914,7 +4914,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4949,7 +4949,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4984,7 +4984,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5019,7 +5019,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5054,7 +5054,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5089,7 +5089,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5134,7 +5134,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5193,7 +5193,7 @@ items:
                         "y": 2
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5319,7 +5319,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5381,7 +5381,7 @@ items:
                         "y": 4
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5555,7 +5555,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5590,7 +5590,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5625,7 +5625,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5660,7 +5660,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5762,7 +5762,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5837,7 +5837,7 @@ items:
                         "y": 14
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6020,7 +6020,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6098,7 +6098,7 @@ items:
                         "y": 28
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6288,7 +6288,7 @@ items:
                         "y": 35
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6432,7 +6432,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6483,7 +6483,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6534,7 +6534,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6585,7 +6585,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6636,7 +6636,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6687,7 +6687,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6738,7 +6738,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6789,7 +6789,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6860,7 +6860,7 @@ items:
                         "y": 70
                     },
                     "id": 18,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7132,7 +7132,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7199,7 +7199,7 @@ items:
                         "y": 6
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7361,7 +7361,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7464,7 +7464,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7534,7 +7534,7 @@ items:
                         "y": 24
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7821,7 +7821,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7927,7 +7927,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7969,7 +7969,7 @@ items:
                         "y": 14
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8152,7 +8152,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8213,7 +8213,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8383,7 +8383,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8434,7 +8434,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8485,7 +8485,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8536,7 +8536,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8587,7 +8587,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8638,7 +8638,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8689,7 +8689,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8748,7 +8748,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8807,7 +8807,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8858,7 +8858,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8912,7 +8912,7 @@ items:
                         "y": 70
                     },
                     "id": 16,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9125,7 +9125,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9160,7 +9160,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9195,7 +9195,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9230,7 +9230,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9265,7 +9265,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9300,7 +9300,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9350,7 +9350,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9409,7 +9409,7 @@ items:
                         "y": 14
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9540,7 +9540,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9638,7 +9638,7 @@ items:
                         "y": 28
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9827,7 +9827,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9886,7 +9886,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10017,7 +10017,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10079,7 +10079,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10281,7 +10281,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10340,7 +10340,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10471,7 +10471,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10516,7 +10516,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10647,7 +10647,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10803,7 +10803,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10862,7 +10862,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10993,7 +10993,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11055,7 +11055,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11206,7 +11206,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11350,7 +11350,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11401,7 +11401,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11452,7 +11452,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11503,7 +11503,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11554,7 +11554,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11605,7 +11605,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11656,7 +11656,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11707,7 +11707,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11921,7 +11921,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12008,7 +12008,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12216,7 +12216,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12306,7 +12306,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12482,7 +12482,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12626,7 +12626,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12677,7 +12677,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12728,7 +12728,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12779,7 +12779,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12830,7 +12830,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12881,7 +12881,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12932,7 +12932,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12983,7 +12983,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13120,7 +13120,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13171,7 +13171,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13222,7 +13222,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13273,7 +13273,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13324,7 +13324,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13375,7 +13375,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13426,7 +13426,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13536,7 +13536,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13587,7 +13587,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13638,7 +13638,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13689,7 +13689,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13756,7 +13756,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13807,7 +13807,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13872,7 +13872,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13939,7 +13939,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13990,7 +13990,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14041,7 +14041,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14160,7 +14160,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14195,7 +14195,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14230,7 +14230,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14265,7 +14265,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14300,7 +14300,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14335,7 +14335,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14386,7 +14386,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14437,7 +14437,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14488,7 +14488,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14539,7 +14539,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14598,7 +14598,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14657,7 +14657,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14708,7 +14708,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14759,7 +14759,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14810,7 +14810,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14861,7 +14861,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14912,7 +14912,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14963,7 +14963,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15014,7 +15014,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15065,7 +15065,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15140,7 +15140,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15191,7 +15191,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15242,7 +15242,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15293,7 +15293,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15432,7 +15432,7 @@ items:
                     },
                     "id": 1,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15486,7 +15486,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15557,7 +15557,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15696,7 +15696,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15742,7 +15742,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15788,7 +15788,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15834,7 +15834,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15880,7 +15880,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15926,7 +15926,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16058,7 +16058,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16098,7 +16098,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16169,7 +16169,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16355,7 +16355,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16406,7 +16406,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16457,7 +16457,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16508,7 +16508,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16559,7 +16559,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16610,7 +16610,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16661,7 +16661,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16712,7 +16712,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16865,7 +16865,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16912,7 +16912,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16974,7 +16974,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17021,7 +17021,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17097,7 +17097,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17166,7 +17166,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17236,7 +17236,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17283,7 +17283,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17345,7 +17345,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17466,7 +17466,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17513,7 +17513,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17575,7 +17575,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17622,7 +17622,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17698,7 +17698,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17767,7 +17767,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17837,7 +17837,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17884,7 +17884,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17946,7 +17946,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18068,7 +18068,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18110,7 +18110,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18190,7 +18190,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18246,7 +18246,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18326,7 +18326,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18467,7 +18467,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18627,7 +18627,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18669,7 +18669,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18791,7 +18791,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18833,7 +18833,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18913,7 +18913,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18993,7 +18993,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19073,7 +19073,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19214,7 +19214,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19374,7 +19374,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19416,7 +19416,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19538,7 +19538,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19580,7 +19580,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19660,7 +19660,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19732,7 +19732,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19812,7 +19812,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19953,7 +19953,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20113,7 +20113,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20155,7 +20155,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20280,7 +20280,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20342,7 +20342,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20392,7 +20392,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20454,7 +20454,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20606,7 +20606,7 @@ items:
                     },
                     "id": 1,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20660,7 +20660,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20706,7 +20706,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20752,7 +20752,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20798,7 +20798,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20844,7 +20844,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20890,7 +20890,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20936,7 +20936,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21087,7 +21087,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21129,7 +21129,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21186,7 +21186,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21243,7 +21243,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21285,7 +21285,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21327,7 +21327,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21369,7 +21369,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21426,7 +21426,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21468,7 +21468,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21525,7 +21525,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21567,7 +21567,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21623,7 +21623,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21664,7 +21664,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21705,7 +21705,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21746,7 +21746,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22047,7 +22047,7 @@ items:
                         "y": 1
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22116,7 +22116,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22163,7 +22163,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22221,7 +22221,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22268,7 +22268,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22351,7 +22351,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22413,7 +22413,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22460,7 +22460,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22522,7 +22522,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22569,7 +22569,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22721,7 +22721,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22772,7 +22772,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22823,7 +22823,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22874,7 +22874,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22925,7 +22925,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22976,7 +22976,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23051,7 +23051,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23102,7 +23102,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23153,7 +23153,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23204,7 +23204,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23255,7 +23255,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23376,7 +23376,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23427,7 +23427,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23502,7 +23502,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23577,7 +23577,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23652,7 +23652,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23703,7 +23703,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23754,7 +23754,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23805,7 +23805,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23856,7 +23856,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23982,7 +23982,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24022,7 +24022,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24062,7 +24062,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24102,7 +24102,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24153,7 +24153,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24204,7 +24204,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24255,7 +24255,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24306,7 +24306,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24357,7 +24357,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24408,7 +24408,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {

--- a/tests/golden/kubernetes_1.33/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.33/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: grafana_rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.33/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.33/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -72,6 +76,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -88,6 +94,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -107,6 +115,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -126,6 +136,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -142,6 +154,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -158,6 +172,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -170,6 +186,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -182,6 +200,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $labels.instance }} {{ $value | humanizePercentage }}
@@ -192,6 +212,8 @@ spec:
             (node_nf_conntrack_entries{job="nodeexporter-default-instance"} / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector on {{ $labels.instance
@@ -202,6 +224,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock at {{ $labels.instance }} is out of sync by more than
@@ -223,6 +247,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock at {{ $labels.instance }} is not synchronising. Ensure
@@ -236,6 +262,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' at {{ $labels.instance
@@ -248,6 +276,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array at {{ $labels.instance
@@ -259,6 +289,8 @@ spec:
             node_md_disks{state="failed",job="nodeexporter-default-instance",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -272,6 +304,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -285,6 +319,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeCPUHighUsage
           annotations:
             description: |
@@ -296,6 +332,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemSaturation
           annotations:
             description: |
@@ -309,6 +347,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryMajorPagesFaults
           annotations:
             description: |
@@ -321,6 +361,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryHighUtilization
           annotations:
             description: |
@@ -332,6 +374,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeDiskIOSaturation
           annotations:
             description: |
@@ -344,6 +388,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceFailed
           annotations:
             description: Systemd service {{ $labels.name }} has entered failed state
@@ -355,6 +401,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceCrashlooping
           annotations:
             description: Systemd service {{ $labels.name }} has being restarted too
@@ -367,6 +415,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeBondingDegraded
           annotations:
             description: Bonding interface {{ $labels.master }} on {{ $labels.instance
@@ -378,6 +428,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.33/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.33/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -46,6 +48,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -80,6 +86,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentRolloutStuck
           annotations:
             description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -93,6 +101,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -113,6 +123,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -127,6 +139,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -154,6 +168,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -188,6 +204,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeContainerWaiting
           annotations:
             description: 'pod/{{ $labels.pod }} in namespace {{ $labels.namespace
@@ -201,6 +219,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -215,6 +235,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -227,6 +249,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -240,6 +264,8 @@ spec:
             kube_job_status_active{job="kubestatemetrics-default-instance"} > 0) > 43200
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -252,6 +278,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePdbNotEnoughHealthyPods
           annotations:
             description: PDB {{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.poddisruptionbudget
@@ -269,6 +297,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -285,6 +315,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -299,6 +331,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeCPUQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted CPU resource
@@ -313,6 +347,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -327,6 +363,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -342,6 +380,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -357,6 +397,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -372,6 +414,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp
@@ -397,6 +441,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -423,6 +469,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -446,6 +494,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -472,6 +522,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeErrors
           annotations:
             description: The persistent volume {{ $labels.persistentvolume }} {{ with
@@ -484,6 +536,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system
       rules:
         - alert: KubeVersionMismatch
@@ -497,6 +551,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientErrors
           annotations:
             description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
@@ -512,6 +568,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-slos
       rules:
         - alert: KubeAPIErrorBudgetBurn
@@ -529,6 +587,8 @@ spec:
             long: 1h
             severity: critical
             short: 5m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -544,6 +604,8 @@ spec:
             long: 6h
             severity: critical
             short: 30m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -559,6 +621,8 @@ spec:
             long: 1d
             severity: warning
             short: 2h
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -574,6 +638,8 @@ spec:
             long: 3d
             severity: warning
             short: 6h
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-apiserver
       rules:
         - alert: KubeClientCertificateExpiration
@@ -589,6 +655,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientCertificateExpiration
           annotations:
             description: A client certificate used to authenticate to kubernetes apiserver
@@ -602,6 +670,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.instance }}/{{ $labels.name
@@ -614,6 +684,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -626,6 +698,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -636,6 +710,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -648,6 +724,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-kubelet
       rules:
         - alert: KubeNodeNotReady
@@ -663,6 +741,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodePressure
           annotations:
             description: '{{ $labels.node }} on cluster {{ $labels.cluster }} has
@@ -677,6 +757,8 @@ spec:
           for: 10m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -688,6 +770,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -711,6 +795,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -725,6 +811,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeEviction
           annotations:
             description: Node {{ $labels.node }} on {{ $labels.cluster }} is evicting
@@ -743,6 +831,8 @@ spec:
           for: 0s
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -755,6 +845,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -767,6 +859,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -778,6 +872,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -789,6 +885,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -800,6 +898,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -811,6 +911,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -823,6 +925,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -835,6 +939,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -845,6 +951,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-scheduler
       rules:
         - alert: KubeSchedulerDown
@@ -857,6 +965,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-controller-manager
       rules:
         - alert: KubeControllerManagerDown
@@ -870,6 +980,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - interval: 3m
       name: kube-apiserver-availability.rules
       rules:

--- a/tests/golden/kubernetes_1.33/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.33/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.34/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.34/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
         - alert: InfoInhibitor
           annotations:
             description: |
@@ -59,6 +63,8 @@ spec:
             == 1
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -73,6 +79,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/kubernetes_1.34/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.34/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorStatusUpdateErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of status update operations
@@ -74,6 +82,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -85,6 +95,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -108,6 +122,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: config-reloaders
       rules:
         - alert: ConfigReloaderSidecarErrors
@@ -122,3 +138,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.34/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.34/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusSDRefreshFailure
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -43,6 +45,8 @@ spec:
           for: 20m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusKubernetesListWatchFailures
           annotations:
             description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -55,6 +59,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -73,6 +79,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% of alerts sent by Prometheus
@@ -92,6 +100,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -105,6 +115,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -116,6 +128,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -127,6 +141,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -158,6 +176,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -170,6 +190,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -192,6 +214,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -211,6 +235,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -232,6 +258,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -255,6 +285,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -268,6 +300,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -281,6 +315,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -293,6 +329,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -306,6 +344,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -317,6 +357,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusHighQueryLoad
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} query API
@@ -330,6 +372,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -349,3 +393,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.34/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.34/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -65,6 +69,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -83,6 +89,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -101,6 +109,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -116,6 +126,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -138,6 +150,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -160,3 +174,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.34/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
+++ b/tests/golden/kubernetes_1.34/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
@@ -54,7 +54,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -102,7 +102,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -174,7 +174,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "repeat": "integration",
                     "targets": [
                         {
@@ -232,7 +232,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "repeat": "integration",
                     "targets": [
                         {
@@ -398,7 +398,7 @@ items:
                     "options": {
                         "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only."
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "title": "Notice",
                     "type": "text"
                 },
@@ -422,7 +422,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -468,7 +468,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -502,7 +502,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -600,7 +600,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -644,7 +644,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -687,7 +687,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -721,7 +721,7 @@ items:
                     },
                     "id": 8,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -819,7 +819,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -863,7 +863,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -906,7 +906,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -949,7 +949,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -992,7 +992,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1038,7 +1038,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1080,7 +1080,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1123,7 +1123,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1165,7 +1165,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1296,7 +1296,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1342,7 +1342,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1413,7 +1413,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1578,7 +1578,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1624,7 +1624,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1670,7 +1670,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1716,7 +1716,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1762,7 +1762,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1808,7 +1808,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1854,7 +1854,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1900,7 +1900,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1946,7 +1946,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1992,7 +1992,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2099,7 +2099,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2150,7 +2150,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2201,7 +2201,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2252,7 +2252,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2303,7 +2303,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2378,7 +2378,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2429,7 +2429,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2480,7 +2480,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2531,7 +2531,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2582,7 +2582,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3327,7 +3327,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3362,7 +3362,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3397,7 +3397,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3432,7 +3432,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3467,7 +3467,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3502,7 +3502,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3552,7 +3552,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3611,7 +3611,7 @@ items:
                         "y": 12
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3768,7 +3768,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3863,7 +3863,7 @@ items:
                         "y": 24
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4040,7 +4040,7 @@ items:
                         "y": 30
                     },
                     "id": 11,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4184,7 +4184,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4235,7 +4235,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4286,7 +4286,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4337,7 +4337,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4388,7 +4388,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4439,7 +4439,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4490,7 +4490,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4541,7 +4541,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4592,7 +4592,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4643,7 +4643,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4714,7 +4714,7 @@ items:
                         "y": 96
                     },
                     "id": 22,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4914,7 +4914,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4949,7 +4949,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4984,7 +4984,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5019,7 +5019,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5054,7 +5054,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5089,7 +5089,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5134,7 +5134,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5193,7 +5193,7 @@ items:
                         "y": 2
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5319,7 +5319,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5381,7 +5381,7 @@ items:
                         "y": 4
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5555,7 +5555,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5590,7 +5590,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5625,7 +5625,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5660,7 +5660,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5762,7 +5762,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5837,7 +5837,7 @@ items:
                         "y": 14
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6020,7 +6020,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6098,7 +6098,7 @@ items:
                         "y": 28
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6288,7 +6288,7 @@ items:
                         "y": 35
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6432,7 +6432,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6483,7 +6483,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6534,7 +6534,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6585,7 +6585,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6636,7 +6636,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6687,7 +6687,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6738,7 +6738,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6789,7 +6789,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6860,7 +6860,7 @@ items:
                         "y": 70
                     },
                     "id": 18,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7132,7 +7132,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7199,7 +7199,7 @@ items:
                         "y": 6
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7361,7 +7361,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7464,7 +7464,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7534,7 +7534,7 @@ items:
                         "y": 24
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7821,7 +7821,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7927,7 +7927,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7969,7 +7969,7 @@ items:
                         "y": 14
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8152,7 +8152,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8213,7 +8213,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8383,7 +8383,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8434,7 +8434,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8485,7 +8485,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8536,7 +8536,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8587,7 +8587,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8638,7 +8638,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8689,7 +8689,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8748,7 +8748,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8807,7 +8807,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8858,7 +8858,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8912,7 +8912,7 @@ items:
                         "y": 70
                     },
                     "id": 16,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9125,7 +9125,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9160,7 +9160,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9195,7 +9195,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9230,7 +9230,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9265,7 +9265,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9300,7 +9300,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9350,7 +9350,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9409,7 +9409,7 @@ items:
                         "y": 14
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9540,7 +9540,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9638,7 +9638,7 @@ items:
                         "y": 28
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9827,7 +9827,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9886,7 +9886,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10017,7 +10017,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10079,7 +10079,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10281,7 +10281,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10340,7 +10340,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10471,7 +10471,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10516,7 +10516,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10647,7 +10647,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10803,7 +10803,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10862,7 +10862,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10993,7 +10993,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11055,7 +11055,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11206,7 +11206,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11350,7 +11350,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11401,7 +11401,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11452,7 +11452,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11503,7 +11503,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11554,7 +11554,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11605,7 +11605,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11656,7 +11656,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11707,7 +11707,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11921,7 +11921,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12008,7 +12008,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12216,7 +12216,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12306,7 +12306,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12482,7 +12482,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12626,7 +12626,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12677,7 +12677,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12728,7 +12728,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12779,7 +12779,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12830,7 +12830,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12881,7 +12881,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12932,7 +12932,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12983,7 +12983,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13120,7 +13120,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13171,7 +13171,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13222,7 +13222,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13273,7 +13273,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13324,7 +13324,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13375,7 +13375,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13426,7 +13426,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13536,7 +13536,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13587,7 +13587,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13638,7 +13638,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13689,7 +13689,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13756,7 +13756,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13807,7 +13807,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13872,7 +13872,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13939,7 +13939,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13990,7 +13990,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14041,7 +14041,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14160,7 +14160,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14195,7 +14195,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14230,7 +14230,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14265,7 +14265,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14300,7 +14300,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14335,7 +14335,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14386,7 +14386,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14437,7 +14437,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14488,7 +14488,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14539,7 +14539,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14598,7 +14598,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14657,7 +14657,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14708,7 +14708,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14759,7 +14759,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14810,7 +14810,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14861,7 +14861,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14912,7 +14912,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14963,7 +14963,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15014,7 +15014,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15065,7 +15065,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15140,7 +15140,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15191,7 +15191,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15242,7 +15242,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15293,7 +15293,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15432,7 +15432,7 @@ items:
                     },
                     "id": 1,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15486,7 +15486,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15557,7 +15557,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15696,7 +15696,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15742,7 +15742,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15788,7 +15788,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15834,7 +15834,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15880,7 +15880,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15926,7 +15926,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16058,7 +16058,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16098,7 +16098,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16169,7 +16169,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16355,7 +16355,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16406,7 +16406,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16457,7 +16457,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16508,7 +16508,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16559,7 +16559,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16610,7 +16610,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16661,7 +16661,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16712,7 +16712,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16865,7 +16865,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16912,7 +16912,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16974,7 +16974,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17021,7 +17021,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17097,7 +17097,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17166,7 +17166,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17236,7 +17236,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17283,7 +17283,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17345,7 +17345,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17466,7 +17466,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17513,7 +17513,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17575,7 +17575,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17622,7 +17622,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17698,7 +17698,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17767,7 +17767,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17837,7 +17837,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17884,7 +17884,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17946,7 +17946,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18068,7 +18068,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18110,7 +18110,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18190,7 +18190,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18246,7 +18246,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18326,7 +18326,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18467,7 +18467,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18627,7 +18627,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18669,7 +18669,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18791,7 +18791,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18833,7 +18833,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18913,7 +18913,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18993,7 +18993,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19073,7 +19073,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19214,7 +19214,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19374,7 +19374,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19416,7 +19416,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19538,7 +19538,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19580,7 +19580,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19660,7 +19660,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19732,7 +19732,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19812,7 +19812,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19953,7 +19953,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20113,7 +20113,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20155,7 +20155,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20280,7 +20280,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20342,7 +20342,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20392,7 +20392,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20454,7 +20454,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20606,7 +20606,7 @@ items:
                     },
                     "id": 1,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20660,7 +20660,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20706,7 +20706,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20752,7 +20752,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20798,7 +20798,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20844,7 +20844,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20890,7 +20890,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20936,7 +20936,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21087,7 +21087,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21129,7 +21129,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21186,7 +21186,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21243,7 +21243,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21285,7 +21285,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21327,7 +21327,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21369,7 +21369,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21426,7 +21426,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21468,7 +21468,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21525,7 +21525,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21567,7 +21567,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21623,7 +21623,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21664,7 +21664,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21705,7 +21705,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21746,7 +21746,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22047,7 +22047,7 @@ items:
                         "y": 1
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22116,7 +22116,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22163,7 +22163,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22221,7 +22221,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22268,7 +22268,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22351,7 +22351,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22413,7 +22413,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22460,7 +22460,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22522,7 +22522,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22569,7 +22569,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22721,7 +22721,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22772,7 +22772,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22823,7 +22823,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22874,7 +22874,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22925,7 +22925,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22976,7 +22976,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23051,7 +23051,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23102,7 +23102,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23153,7 +23153,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23204,7 +23204,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23255,7 +23255,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23376,7 +23376,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23427,7 +23427,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23502,7 +23502,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23577,7 +23577,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23652,7 +23652,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23703,7 +23703,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23754,7 +23754,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23805,7 +23805,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23856,7 +23856,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23982,7 +23982,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24022,7 +24022,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24062,7 +24062,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24102,7 +24102,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24153,7 +24153,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24204,7 +24204,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24255,7 +24255,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24306,7 +24306,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24357,7 +24357,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24408,7 +24408,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {

--- a/tests/golden/kubernetes_1.34/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.34/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: grafana_rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.34/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.34/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -72,6 +76,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -88,6 +94,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -107,6 +115,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -126,6 +136,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -142,6 +154,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -158,6 +172,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -170,6 +186,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -182,6 +200,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $labels.instance }} {{ $value | humanizePercentage }}
@@ -192,6 +212,8 @@ spec:
             (node_nf_conntrack_entries{job="nodeexporter-default-instance"} / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector on {{ $labels.instance
@@ -202,6 +224,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock at {{ $labels.instance }} is out of sync by more than
@@ -223,6 +247,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock at {{ $labels.instance }} is not synchronising. Ensure
@@ -236,6 +262,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' at {{ $labels.instance
@@ -248,6 +276,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array at {{ $labels.instance
@@ -259,6 +289,8 @@ spec:
             node_md_disks{state="failed",job="nodeexporter-default-instance",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -272,6 +304,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -285,6 +319,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeCPUHighUsage
           annotations:
             description: |
@@ -296,6 +332,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemSaturation
           annotations:
             description: |
@@ -309,6 +347,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryMajorPagesFaults
           annotations:
             description: |
@@ -321,6 +361,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryHighUtilization
           annotations:
             description: |
@@ -332,6 +374,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeDiskIOSaturation
           annotations:
             description: |
@@ -344,6 +388,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceFailed
           annotations:
             description: Systemd service {{ $labels.name }} has entered failed state
@@ -355,6 +401,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceCrashlooping
           annotations:
             description: Systemd service {{ $labels.name }} has being restarted too
@@ -367,6 +415,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeBondingDegraded
           annotations:
             description: Bonding interface {{ $labels.master }} on {{ $labels.instance
@@ -378,6 +428,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.34/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.34/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -46,6 +48,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -80,6 +86,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentRolloutStuck
           annotations:
             description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -93,6 +101,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -113,6 +123,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -127,6 +139,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -154,6 +168,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -188,6 +204,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeContainerWaiting
           annotations:
             description: 'pod/{{ $labels.pod }} in namespace {{ $labels.namespace
@@ -201,6 +219,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -215,6 +235,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -227,6 +249,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -240,6 +264,8 @@ spec:
             kube_job_status_active{job="kubestatemetrics-default-instance"} > 0) > 43200
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -252,6 +278,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePdbNotEnoughHealthyPods
           annotations:
             description: PDB {{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.poddisruptionbudget
@@ -269,6 +297,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -285,6 +315,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -299,6 +331,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeCPUQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }}  has overcommitted CPU resource
@@ -313,6 +347,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -327,6 +363,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -342,6 +380,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -357,6 +397,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -372,6 +414,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp
@@ -397,6 +441,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -423,6 +469,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -446,6 +494,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -472,6 +522,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeErrors
           annotations:
             description: The persistent volume {{ $labels.persistentvolume }} {{ with
@@ -484,6 +536,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system
       rules:
         - alert: KubeVersionMismatch
@@ -497,6 +551,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientErrors
           annotations:
             description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
@@ -512,6 +568,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-slos
       rules:
         - alert: KubeAPIErrorBudgetBurn
@@ -529,6 +587,8 @@ spec:
             long: 1h
             severity: critical
             short: 5m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -544,6 +604,8 @@ spec:
             long: 6h
             severity: critical
             short: 30m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -559,6 +621,8 @@ spec:
             long: 1d
             severity: warning
             short: 2h
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -574,6 +638,8 @@ spec:
             long: 3d
             severity: warning
             short: 6h
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-apiserver
       rules:
         - alert: KubeClientCertificateExpiration
@@ -589,6 +655,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientCertificateExpiration
           annotations:
             description: A client certificate used to authenticate to kubernetes apiserver
@@ -602,6 +670,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.instance }}/{{ $labels.name
@@ -614,6 +684,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -626,6 +698,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -636,6 +710,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -648,6 +724,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-kubelet
       rules:
         - alert: KubeNodeNotReady
@@ -663,6 +741,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodePressure
           annotations:
             description: '{{ $labels.node }} on cluster {{ $labels.cluster }} has
@@ -677,6 +757,8 @@ spec:
           for: 10m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -688,6 +770,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -711,6 +795,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -725,6 +811,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeEviction
           annotations:
             description: Node {{ $labels.node }} on {{ $labels.cluster }} is evicting
@@ -743,6 +831,8 @@ spec:
           for: 0s
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -755,6 +845,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -767,6 +859,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -778,6 +872,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -789,6 +885,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -800,6 +898,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -811,6 +911,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -823,6 +925,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -835,6 +939,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -845,6 +951,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-scheduler
       rules:
         - alert: KubeSchedulerDown
@@ -857,6 +965,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-controller-manager
       rules:
         - alert: KubeControllerManagerDown
@@ -870,6 +980,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - interval: 3m
       name: kube-apiserver-availability.rules
       rules:

--- a/tests/golden/kubernetes_1.34/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.34/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.35/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.35/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
         - alert: InfoInhibitor
           annotations:
             description: |
@@ -59,6 +63,8 @@ spec:
             == 1
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -73,6 +79,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/kubernetes_1.35/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.35/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorStatusUpdateErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of status update operations
@@ -74,6 +82,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -85,6 +95,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -108,6 +122,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: config-reloaders
       rules:
         - alert: ConfigReloaderSidecarErrors
@@ -122,3 +138,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.35/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.35/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusSDRefreshFailure
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -43,6 +45,8 @@ spec:
           for: 20m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusKubernetesListWatchFailures
           annotations:
             description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -55,6 +59,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -73,6 +79,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% of alerts sent by Prometheus
@@ -92,6 +100,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -105,6 +115,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -116,6 +128,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -127,6 +141,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -158,6 +176,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -170,6 +190,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -192,6 +214,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -211,6 +235,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -232,6 +258,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -255,6 +285,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -268,6 +300,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -281,6 +315,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -293,6 +329,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -306,6 +344,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -317,6 +357,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusHighQueryLoad
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} query API
@@ -330,6 +372,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -349,3 +393,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.35/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.35/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -65,6 +69,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -83,6 +89,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -101,6 +109,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -116,6 +126,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -138,6 +150,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -160,3 +174,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.35/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
+++ b/tests/golden/kubernetes_1.35/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
@@ -54,7 +54,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -102,7 +102,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -174,7 +174,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "repeat": "integration",
                     "targets": [
                         {
@@ -232,7 +232,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "repeat": "integration",
                     "targets": [
                         {
@@ -398,7 +398,7 @@ items:
                     "options": {
                         "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only."
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "title": "Notice",
                     "type": "text"
                 },
@@ -422,7 +422,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -468,7 +468,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -502,7 +502,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -600,7 +600,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -644,7 +644,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -687,7 +687,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -721,7 +721,7 @@ items:
                     },
                     "id": 8,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -819,7 +819,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -863,7 +863,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -906,7 +906,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -949,7 +949,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -992,7 +992,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1038,7 +1038,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1080,7 +1080,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1123,7 +1123,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1165,7 +1165,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1296,7 +1296,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1342,7 +1342,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1413,7 +1413,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1578,7 +1578,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1624,7 +1624,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1670,7 +1670,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1716,7 +1716,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1762,7 +1762,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1808,7 +1808,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1854,7 +1854,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1900,7 +1900,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1946,7 +1946,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1992,7 +1992,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2099,7 +2099,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2150,7 +2150,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2201,7 +2201,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2252,7 +2252,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2303,7 +2303,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2378,7 +2378,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2429,7 +2429,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2480,7 +2480,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2531,7 +2531,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2582,7 +2582,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3327,7 +3327,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3362,7 +3362,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3397,7 +3397,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3432,7 +3432,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3467,7 +3467,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3502,7 +3502,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3552,7 +3552,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3611,7 +3611,7 @@ items:
                         "y": 12
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3768,7 +3768,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3863,7 +3863,7 @@ items:
                         "y": 24
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4040,7 +4040,7 @@ items:
                         "y": 30
                     },
                     "id": 11,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4184,7 +4184,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4235,7 +4235,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4286,7 +4286,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4337,7 +4337,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4388,7 +4388,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4439,7 +4439,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4490,7 +4490,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4541,7 +4541,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4592,7 +4592,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4643,7 +4643,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4714,7 +4714,7 @@ items:
                         "y": 96
                     },
                     "id": 22,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4914,7 +4914,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4949,7 +4949,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4984,7 +4984,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5019,7 +5019,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5054,7 +5054,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5089,7 +5089,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5134,7 +5134,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5193,7 +5193,7 @@ items:
                         "y": 2
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5319,7 +5319,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5381,7 +5381,7 @@ items:
                         "y": 4
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5555,7 +5555,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5590,7 +5590,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5625,7 +5625,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5660,7 +5660,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5762,7 +5762,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5837,7 +5837,7 @@ items:
                         "y": 14
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6020,7 +6020,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6098,7 +6098,7 @@ items:
                         "y": 28
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6288,7 +6288,7 @@ items:
                         "y": 35
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6432,7 +6432,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6483,7 +6483,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6534,7 +6534,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6585,7 +6585,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6636,7 +6636,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6687,7 +6687,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6738,7 +6738,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6789,7 +6789,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6860,7 +6860,7 @@ items:
                         "y": 70
                     },
                     "id": 18,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7132,7 +7132,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7199,7 +7199,7 @@ items:
                         "y": 6
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7361,7 +7361,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7464,7 +7464,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7534,7 +7534,7 @@ items:
                         "y": 24
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7821,7 +7821,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7927,7 +7927,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7969,7 +7969,7 @@ items:
                         "y": 14
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8152,7 +8152,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8213,7 +8213,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8383,7 +8383,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8434,7 +8434,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8485,7 +8485,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8536,7 +8536,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8587,7 +8587,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8638,7 +8638,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8689,7 +8689,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8748,7 +8748,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8807,7 +8807,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8858,7 +8858,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8912,7 +8912,7 @@ items:
                         "y": 70
                     },
                     "id": 16,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9125,7 +9125,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9160,7 +9160,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9195,7 +9195,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9230,7 +9230,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9265,7 +9265,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9300,7 +9300,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9350,7 +9350,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9409,7 +9409,7 @@ items:
                         "y": 14
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9540,7 +9540,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9638,7 +9638,7 @@ items:
                         "y": 28
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9827,7 +9827,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9886,7 +9886,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10017,7 +10017,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10079,7 +10079,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10281,7 +10281,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10340,7 +10340,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10471,7 +10471,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10516,7 +10516,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10647,7 +10647,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10803,7 +10803,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10862,7 +10862,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10993,7 +10993,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11055,7 +11055,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11206,7 +11206,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11350,7 +11350,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11401,7 +11401,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11452,7 +11452,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11503,7 +11503,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11554,7 +11554,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11605,7 +11605,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11656,7 +11656,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11707,7 +11707,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11921,7 +11921,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12008,7 +12008,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12216,7 +12216,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12306,7 +12306,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12482,7 +12482,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12626,7 +12626,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12677,7 +12677,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12728,7 +12728,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12779,7 +12779,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12830,7 +12830,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12881,7 +12881,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12932,7 +12932,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12983,7 +12983,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13120,7 +13120,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13171,7 +13171,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13222,7 +13222,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13273,7 +13273,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13324,7 +13324,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13375,7 +13375,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13426,7 +13426,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13536,7 +13536,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13587,7 +13587,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13638,7 +13638,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13689,7 +13689,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13756,7 +13756,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13807,7 +13807,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13872,7 +13872,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13939,7 +13939,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13990,7 +13990,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14041,7 +14041,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14160,7 +14160,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14195,7 +14195,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14230,7 +14230,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14265,7 +14265,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14300,7 +14300,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14335,7 +14335,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14386,7 +14386,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14437,7 +14437,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14488,7 +14488,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14539,7 +14539,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14598,7 +14598,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14657,7 +14657,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14708,7 +14708,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14759,7 +14759,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14810,7 +14810,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14861,7 +14861,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14912,7 +14912,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14963,7 +14963,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15014,7 +15014,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15065,7 +15065,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15140,7 +15140,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15191,7 +15191,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15242,7 +15242,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15293,7 +15293,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15432,7 +15432,7 @@ items:
                     },
                     "id": 1,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15486,7 +15486,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15557,7 +15557,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15696,7 +15696,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15742,7 +15742,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15788,7 +15788,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15834,7 +15834,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15880,7 +15880,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15926,7 +15926,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16058,7 +16058,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16098,7 +16098,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16169,7 +16169,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16355,7 +16355,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16406,7 +16406,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16457,7 +16457,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16508,7 +16508,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16559,7 +16559,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16610,7 +16610,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16661,7 +16661,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16712,7 +16712,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16865,7 +16865,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16912,7 +16912,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16974,7 +16974,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17021,7 +17021,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17097,7 +17097,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17166,7 +17166,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17236,7 +17236,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17283,7 +17283,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17345,7 +17345,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17466,7 +17466,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17513,7 +17513,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17575,7 +17575,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17622,7 +17622,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17698,7 +17698,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17767,7 +17767,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17837,7 +17837,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17884,7 +17884,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17946,7 +17946,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18068,7 +18068,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18110,7 +18110,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18190,7 +18190,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18246,7 +18246,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18326,7 +18326,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18467,7 +18467,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18627,7 +18627,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18669,7 +18669,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18791,7 +18791,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18833,7 +18833,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18913,7 +18913,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18993,7 +18993,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19073,7 +19073,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19214,7 +19214,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19374,7 +19374,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19416,7 +19416,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19538,7 +19538,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19580,7 +19580,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19660,7 +19660,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19732,7 +19732,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19812,7 +19812,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19953,7 +19953,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20113,7 +20113,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20155,7 +20155,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20280,7 +20280,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20342,7 +20342,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20392,7 +20392,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20454,7 +20454,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20606,7 +20606,7 @@ items:
                     },
                     "id": 1,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20660,7 +20660,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20706,7 +20706,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20752,7 +20752,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20798,7 +20798,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20844,7 +20844,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20890,7 +20890,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20936,7 +20936,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21087,7 +21087,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21129,7 +21129,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21186,7 +21186,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21243,7 +21243,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21285,7 +21285,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21327,7 +21327,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21369,7 +21369,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21426,7 +21426,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21468,7 +21468,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21525,7 +21525,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21567,7 +21567,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21623,7 +21623,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21664,7 +21664,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21705,7 +21705,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21746,7 +21746,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22047,7 +22047,7 @@ items:
                         "y": 1
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22116,7 +22116,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22163,7 +22163,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22221,7 +22221,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22268,7 +22268,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22351,7 +22351,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22413,7 +22413,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22460,7 +22460,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22522,7 +22522,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22569,7 +22569,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22721,7 +22721,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22772,7 +22772,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22823,7 +22823,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22874,7 +22874,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22925,7 +22925,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22976,7 +22976,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23051,7 +23051,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23102,7 +23102,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23153,7 +23153,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23204,7 +23204,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23255,7 +23255,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23376,7 +23376,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23427,7 +23427,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23502,7 +23502,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23577,7 +23577,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23652,7 +23652,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23703,7 +23703,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23754,7 +23754,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23805,7 +23805,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23856,7 +23856,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23982,7 +23982,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24022,7 +24022,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24062,7 +24062,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24102,7 +24102,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24153,7 +24153,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24204,7 +24204,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24255,7 +24255,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24306,7 +24306,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24357,7 +24357,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24408,7 +24408,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {

--- a/tests/golden/kubernetes_1.35/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.35/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: grafana_rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.35/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.35/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -72,6 +76,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -88,6 +94,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -107,6 +115,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -126,6 +136,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -142,6 +154,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -158,6 +172,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -170,6 +186,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -182,6 +200,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $labels.instance }} {{ $value | humanizePercentage }}
@@ -192,6 +212,8 @@ spec:
             (node_nf_conntrack_entries{job="nodeexporter-default-instance"} / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector on {{ $labels.instance
@@ -202,6 +224,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock at {{ $labels.instance }} is out of sync by more than
@@ -223,6 +247,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock at {{ $labels.instance }} is not synchronising. Ensure
@@ -236,6 +262,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' at {{ $labels.instance
@@ -248,6 +276,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array at {{ $labels.instance
@@ -259,6 +289,8 @@ spec:
             node_md_disks{state="failed",job="nodeexporter-default-instance",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -272,6 +304,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -285,6 +319,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeCPUHighUsage
           annotations:
             description: |
@@ -296,6 +332,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemSaturation
           annotations:
             description: |
@@ -309,6 +347,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryMajorPagesFaults
           annotations:
             description: |
@@ -321,6 +361,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryHighUtilization
           annotations:
             description: |
@@ -332,6 +374,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeDiskIOSaturation
           annotations:
             description: |
@@ -344,6 +388,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceFailed
           annotations:
             description: Systemd service {{ $labels.name }} has entered failed state
@@ -355,6 +401,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceCrashlooping
           annotations:
             description: Systemd service {{ $labels.name }} has being restarted too
@@ -367,6 +415,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeBondingDegraded
           annotations:
             description: Bonding interface {{ $labels.master }} on {{ $labels.instance
@@ -378,6 +428,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.35/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.35/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -47,6 +49,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -61,6 +65,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -81,6 +87,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentRolloutStuck
           annotations:
             description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -94,6 +102,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -114,6 +124,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -128,6 +140,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -155,6 +169,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -189,6 +205,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeContainerWaiting
           annotations:
             description: 'pod/{{ $labels.pod }} in namespace {{ $labels.namespace
@@ -202,6 +220,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -216,6 +236,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -228,6 +250,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -241,6 +265,8 @@ spec:
             kube_job_status_active{job="kubestatemetrics-default-instance"} > 0) > 43200
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -253,6 +279,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePdbNotEnoughHealthyPods
           annotations:
             description: PDB {{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.poddisruptionbudget
@@ -270,6 +298,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -307,6 +337,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -342,6 +374,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeCPUQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted CPU resource
@@ -359,6 +393,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -376,6 +412,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -391,6 +429,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -406,6 +446,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -421,6 +463,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp
@@ -446,6 +490,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -472,6 +518,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -495,6 +543,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -521,6 +571,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeErrors
           annotations:
             description: The persistent volume {{ $labels.persistentvolume }} {{ with
@@ -533,6 +585,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system
       rules:
         - alert: KubeVersionMismatch
@@ -546,6 +600,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientErrors
           annotations:
             description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
@@ -561,6 +617,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-slos
       rules:
         - alert: KubeAPIErrorBudgetBurn
@@ -578,6 +636,8 @@ spec:
             long: 1h
             severity: critical
             short: 5m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -593,6 +653,8 @@ spec:
             long: 6h
             severity: critical
             short: 30m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -608,6 +670,8 @@ spec:
             long: 1d
             severity: warning
             short: 2h
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -623,6 +687,8 @@ spec:
             long: 3d
             severity: warning
             short: 6h
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-apiserver
       rules:
         - alert: KubeClientCertificateExpiration
@@ -638,6 +704,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientCertificateExpiration
           annotations:
             description: A client certificate used to authenticate to kubernetes apiserver
@@ -651,6 +719,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.instance }}/{{ $labels.name
@@ -663,6 +733,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -675,6 +747,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -685,6 +759,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -697,6 +773,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-kubelet
       rules:
         - alert: KubeNodeNotReady
@@ -712,6 +790,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodePressure
           annotations:
             description: '{{ $labels.node }} on cluster {{ $labels.cluster }} has
@@ -726,6 +806,8 @@ spec:
           for: 10m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -737,6 +819,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -760,6 +844,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -774,6 +860,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeEviction
           annotations:
             description: Node {{ $labels.node }} on {{ $labels.cluster }} is evicting
@@ -792,6 +880,8 @@ spec:
           for: 0s
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -804,6 +894,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -827,6 +919,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -838,6 +932,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -849,6 +945,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -860,6 +958,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -871,6 +971,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -883,6 +985,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -895,6 +999,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -905,6 +1011,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-scheduler
       rules:
         - alert: KubeSchedulerDown
@@ -917,6 +1025,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-controller-manager
       rules:
         - alert: KubeControllerManagerDown
@@ -930,6 +1040,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - interval: 3m
       name: kube-apiserver-availability.rules
       rules:

--- a/tests/golden/kubernetes_1.35/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.35/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.36/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.36/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
         - alert: InfoInhibitor
           annotations:
             description: |
@@ -59,6 +63,8 @@ spec:
             = "firing", severity =~ "warning|critical"} == 1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -73,6 +79,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/kubernetes_1.36/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.36/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorStatusUpdateErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of status update operations
@@ -74,6 +82,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -85,6 +95,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -108,6 +122,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: config-reloaders
       rules:
         - alert: ConfigReloaderSidecarErrors
@@ -122,3 +138,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.36/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.36/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusSDRefreshFailure
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -43,6 +45,8 @@ spec:
           for: 20m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusKubernetesListWatchFailures
           annotations:
             description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -55,6 +59,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -73,6 +79,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% of alerts sent by Prometheus
@@ -92,6 +100,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -105,6 +115,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -116,6 +128,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -127,6 +141,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -158,6 +176,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -170,6 +190,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -192,6 +214,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -211,6 +235,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -232,6 +258,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -255,6 +285,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -268,6 +300,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -281,6 +315,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -293,6 +329,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -306,6 +344,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -317,6 +357,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusHighQueryLoad
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} query API
@@ -330,6 +372,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -349,3 +393,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.36/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.36/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -65,6 +69,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -83,6 +89,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -101,6 +109,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -116,6 +126,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -138,6 +150,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -160,3 +174,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/kubernetes_1.36/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
+++ b/tests/golden/kubernetes_1.36/prometheus/prometheus/40_default-instance_grafana_dashboardDefinitions.yaml
@@ -54,7 +54,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -102,7 +102,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -174,7 +174,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "repeat": "integration",
                     "targets": [
                         {
@@ -232,7 +232,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "repeat": "integration",
                     "targets": [
                         {
@@ -398,7 +398,7 @@ items:
                     "options": {
                         "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only."
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "title": "Notice",
                     "type": "text"
                 },
@@ -422,7 +422,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -468,7 +468,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -502,7 +502,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -600,7 +600,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -644,7 +644,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -687,7 +687,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -721,7 +721,7 @@ items:
                     },
                     "id": 8,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -819,7 +819,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -863,7 +863,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -906,7 +906,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -949,7 +949,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -992,7 +992,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1038,7 +1038,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1080,7 +1080,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1123,7 +1123,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1165,7 +1165,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1296,7 +1296,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1342,7 +1342,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1413,7 +1413,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1578,7 +1578,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1624,7 +1624,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1670,7 +1670,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1716,7 +1716,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1762,7 +1762,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1808,7 +1808,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1854,7 +1854,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1900,7 +1900,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1946,7 +1946,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -1992,7 +1992,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2099,7 +2099,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2150,7 +2150,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2201,7 +2201,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2252,7 +2252,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2303,7 +2303,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2378,7 +2378,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2429,7 +2429,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2480,7 +2480,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2531,7 +2531,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -2582,7 +2582,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3322,7 +3322,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3357,7 +3357,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3392,7 +3392,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3427,7 +3427,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3462,7 +3462,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3497,7 +3497,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3547,7 +3547,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3606,7 +3606,7 @@ items:
                         "y": 12
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3763,7 +3763,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -3858,7 +3858,7 @@ items:
                         "y": 24
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4035,7 +4035,7 @@ items:
                         "y": 30
                     },
                     "id": 11,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4179,7 +4179,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4230,7 +4230,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4281,7 +4281,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4332,7 +4332,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4383,7 +4383,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4434,7 +4434,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4485,7 +4485,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4536,7 +4536,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4587,7 +4587,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4638,7 +4638,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4709,7 +4709,7 @@ items:
                         "y": 96
                     },
                     "id": 22,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4909,7 +4909,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4944,7 +4944,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -4979,7 +4979,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5014,7 +5014,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5049,7 +5049,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5084,7 +5084,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5129,7 +5129,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5188,7 +5188,7 @@ items:
                         "y": 2
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5314,7 +5314,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5376,7 +5376,7 @@ items:
                         "y": 4
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5550,7 +5550,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5585,7 +5585,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5620,7 +5620,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5655,7 +5655,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5757,7 +5757,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -5832,7 +5832,7 @@ items:
                         "y": 14
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6015,7 +6015,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6093,7 +6093,7 @@ items:
                         "y": 28
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6283,7 +6283,7 @@ items:
                         "y": 35
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6427,7 +6427,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6478,7 +6478,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6529,7 +6529,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6580,7 +6580,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6631,7 +6631,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6682,7 +6682,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6733,7 +6733,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6784,7 +6784,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -6855,7 +6855,7 @@ items:
                         "y": 70
                     },
                     "id": 18,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7170,7 +7170,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7245,7 +7245,7 @@ items:
                         "y": 6
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7450,7 +7450,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7604,7 +7604,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7682,7 +7682,7 @@ items:
                         "y": 24
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -7969,7 +7969,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8075,7 +8075,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8117,7 +8117,7 @@ items:
                         "y": 14
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8300,7 +8300,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8361,7 +8361,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8531,7 +8531,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8582,7 +8582,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8633,7 +8633,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8684,7 +8684,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8735,7 +8735,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8786,7 +8786,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8837,7 +8837,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8896,7 +8896,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -8955,7 +8955,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9006,7 +9006,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9060,7 +9060,7 @@ items:
                         "y": 70
                     },
                     "id": 16,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9286,7 +9286,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9321,7 +9321,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9356,7 +9356,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9391,7 +9391,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9426,7 +9426,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9461,7 +9461,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9511,7 +9511,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9570,7 +9570,7 @@ items:
                         "y": 14
                     },
                     "id": 8,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9701,7 +9701,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -9799,7 +9799,7 @@ items:
                         "y": 28
                     },
                     "id": 10,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10001,7 +10001,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10060,7 +10060,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10191,7 +10191,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10253,7 +10253,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10468,7 +10468,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10527,7 +10527,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10658,7 +10658,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10703,7 +10703,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10834,7 +10834,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -10990,7 +10990,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11049,7 +11049,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11180,7 +11180,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11242,7 +11242,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11393,7 +11393,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11537,7 +11537,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11588,7 +11588,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11639,7 +11639,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11690,7 +11690,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11741,7 +11741,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11792,7 +11792,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11843,7 +11843,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -11894,7 +11894,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12109,7 +12109,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12196,7 +12196,7 @@ items:
                         "y": 7
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12404,7 +12404,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12494,7 +12494,7 @@ items:
                         "y": 21
                     },
                     "id": 4,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12670,7 +12670,7 @@ items:
                         "y": 28
                     },
                     "id": 5,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12814,7 +12814,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12865,7 +12865,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12916,7 +12916,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -12967,7 +12967,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13018,7 +13018,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13069,7 +13069,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13120,7 +13120,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13171,7 +13171,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13321,7 +13321,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13372,7 +13372,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13423,7 +13423,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13474,7 +13474,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13525,7 +13525,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13576,7 +13576,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13627,7 +13627,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13750,7 +13750,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13801,7 +13801,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13852,7 +13852,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13903,7 +13903,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -13970,7 +13970,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14021,7 +14021,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14086,7 +14086,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14153,7 +14153,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14204,7 +14204,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14255,7 +14255,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14374,7 +14374,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14409,7 +14409,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14444,7 +14444,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14479,7 +14479,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14514,7 +14514,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14549,7 +14549,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14600,7 +14600,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14651,7 +14651,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14702,7 +14702,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14753,7 +14753,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14812,7 +14812,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14871,7 +14871,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14922,7 +14922,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -14973,7 +14973,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15024,7 +15024,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15075,7 +15075,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15126,7 +15126,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15177,7 +15177,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15228,7 +15228,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15279,7 +15279,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15354,7 +15354,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15405,7 +15405,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15456,7 +15456,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15507,7 +15507,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15646,7 +15646,7 @@ items:
                     },
                     "id": 1,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15700,7 +15700,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15771,7 +15771,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15910,7 +15910,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -15956,7 +15956,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16002,7 +16002,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16048,7 +16048,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16094,7 +16094,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16140,7 +16140,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16272,7 +16272,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16312,7 +16312,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16383,7 +16383,7 @@ items:
                         "y": 9
                     },
                     "id": 3,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16569,7 +16569,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16620,7 +16620,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16671,7 +16671,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16722,7 +16722,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16773,7 +16773,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16824,7 +16824,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16875,7 +16875,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -16926,7 +16926,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17079,7 +17079,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17126,7 +17126,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17188,7 +17188,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17235,7 +17235,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17311,7 +17311,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17380,7 +17380,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17450,7 +17450,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17497,7 +17497,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17559,7 +17559,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17673,7 +17673,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17720,7 +17720,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17782,7 +17782,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17829,7 +17829,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17905,7 +17905,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -17974,7 +17974,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18044,7 +18044,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18091,7 +18091,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18153,7 +18153,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18276,7 +18276,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18318,7 +18318,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18398,7 +18398,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18454,7 +18454,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18534,7 +18534,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18675,7 +18675,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18835,7 +18835,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -18877,7 +18877,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19001,7 +19001,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19043,7 +19043,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19123,7 +19123,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19203,7 +19203,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19283,7 +19283,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19424,7 +19424,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19584,7 +19584,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19626,7 +19626,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19750,7 +19750,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19792,7 +19792,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19872,7 +19872,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -19944,7 +19944,7 @@ items:
                         "y": 9
                     },
                     "id": 6,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20024,7 +20024,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20165,7 +20165,7 @@ items:
                         "y": 19
                     },
                     "id": 9,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20325,7 +20325,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20367,7 +20367,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20494,7 +20494,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20556,7 +20556,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20606,7 +20606,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20668,7 +20668,7 @@ items:
                     },
                     "id": 4,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20820,7 +20820,7 @@ items:
                     },
                     "id": 1,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20874,7 +20874,7 @@ items:
                     },
                     "id": 2,
                     "interval": "1m",
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20920,7 +20920,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -20966,7 +20966,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21012,7 +21012,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21058,7 +21058,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21104,7 +21104,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21150,7 +21150,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21301,7 +21301,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21343,7 +21343,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21400,7 +21400,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21457,7 +21457,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21499,7 +21499,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21541,7 +21541,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21583,7 +21583,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21640,7 +21640,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21682,7 +21682,7 @@ items:
                             "mode": "multi"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21739,7 +21739,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21781,7 +21781,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21837,7 +21837,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21878,7 +21878,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21919,7 +21919,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -21960,7 +21960,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22262,7 +22262,7 @@ items:
                         "y": 1
                     },
                     "id": 2,
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22331,7 +22331,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22378,7 +22378,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22436,7 +22436,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22483,7 +22483,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22566,7 +22566,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22628,7 +22628,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22675,7 +22675,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22737,7 +22737,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22784,7 +22784,7 @@ items:
                             "sort": "desc"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22937,7 +22937,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -22988,7 +22988,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23039,7 +23039,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23090,7 +23090,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23141,7 +23141,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23192,7 +23192,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23267,7 +23267,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23318,7 +23318,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23369,7 +23369,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23420,7 +23420,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23471,7 +23471,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23592,7 +23592,7 @@ items:
                     "options": {
                         "colorMode": "none"
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23643,7 +23643,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23718,7 +23718,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23793,7 +23793,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23868,7 +23868,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23919,7 +23919,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -23970,7 +23970,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24021,7 +24021,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24072,7 +24072,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24198,7 +24198,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24238,7 +24238,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24278,7 +24278,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24318,7 +24318,7 @@ items:
                         "displayMode": "basic",
                         "showUnfilled": false
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24369,7 +24369,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24420,7 +24420,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24471,7 +24471,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24522,7 +24522,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24573,7 +24573,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {
@@ -24624,7 +24624,7 @@ items:
                             "mode": "single"
                         }
                     },
-                    "pluginVersion": "v11.4.0",
+                    "pluginVersion": "v13.0.0",
                     "targets": [
                         {
                             "datasource": {

--- a/tests/golden/kubernetes_1.36/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.36/prometheus/prometheus/40_default-instance_grafana_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: grafana_rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.36/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.36/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -72,6 +76,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -88,6 +94,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -107,6 +115,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -126,6 +136,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -142,6 +154,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
@@ -158,6 +172,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -170,6 +186,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -182,6 +200,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $labels.instance }} {{ $value | humanizePercentage }}
@@ -192,6 +212,8 @@ spec:
             (node_nf_conntrack_entries{job="nodeexporter-default-instance"} / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector on {{ $labels.instance
@@ -202,6 +224,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock at {{ $labels.instance }} is out of sync by more than
@@ -223,6 +247,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock at {{ $labels.instance }} is not synchronising. Ensure
@@ -236,6 +262,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' at {{ $labels.instance
@@ -248,6 +276,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array at {{ $labels.instance
@@ -259,6 +289,8 @@ spec:
             node_md_disks{state="failed",job="nodeexporter-default-instance",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -272,6 +304,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -285,6 +319,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeCPUHighUsage
           annotations:
             description: |
@@ -296,6 +332,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemSaturation
           annotations:
             description: |
@@ -309,6 +347,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryMajorPagesFaults
           annotations:
             description: |
@@ -321,6 +361,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeMemoryHighUtilization
           annotations:
             description: |
@@ -332,6 +374,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeDiskIOSaturation
           annotations:
             description: |
@@ -344,6 +388,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceFailed
           annotations:
             description: Systemd service {{ $labels.name }} has entered failed state
@@ -355,6 +401,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeSystemdServiceCrashlooping
           annotations:
             description: Systemd service {{ $labels.name }} has being restarted too
@@ -367,6 +415,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeBondingDegraded
           annotations:
             description: Bonding interface {{ $labels.master }} on {{ $labels.instance
@@ -378,6 +428,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/kubernetes_1.36/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.36/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -47,6 +49,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -61,6 +65,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -81,6 +87,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentRolloutStuck
           annotations:
             description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -94,6 +102,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -114,6 +124,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -128,6 +140,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -155,6 +169,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -189,6 +205,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeContainerWaiting
           annotations:
             description: 'pod/{{ $labels.pod }} in namespace {{ $labels.namespace
@@ -202,6 +220,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -216,6 +236,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -228,6 +250,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -241,6 +265,8 @@ spec:
             kube_job_status_active{job="kubestatemetrics-default-instance"} > 0) > 43200
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -253,6 +279,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePdbNotEnoughHealthyPods
           annotations:
             description: PDB {{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.poddisruptionbudget
@@ -270,6 +298,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -307,6 +337,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -342,6 +374,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeCPUQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted CPU resource
@@ -359,6 +393,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster {{ $labels.cluster }} has overcommitted memory resource
@@ -376,6 +412,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -397,6 +435,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -418,6 +458,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -438,6 +480,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp
@@ -463,6 +507,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -489,6 +535,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -512,6 +560,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -538,6 +588,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeErrors
           annotations:
             description: The persistent volume {{ $labels.persistentvolume }} {{ with
@@ -550,6 +602,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system
       rules:
         - alert: KubeVersionMismatch
@@ -563,6 +617,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientErrors
           annotations:
             description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
@@ -578,6 +634,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-slos
       rules:
         - alert: KubeAPIErrorBudgetBurn
@@ -595,6 +653,8 @@ spec:
             long: 1h
             severity: critical
             short: 5m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -610,6 +670,8 @@ spec:
             long: 6h
             severity: critical
             short: 30m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -625,6 +687,8 @@ spec:
             long: 1d
             severity: warning
             short: 2h
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget on cluster
@@ -640,6 +704,8 @@ spec:
             long: 3d
             severity: warning
             short: 6h
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-apiserver
       rules:
         - alert: KubeClientCertificateExpiration
@@ -655,6 +721,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientCertificateExpiration
           annotations:
             description: A client certificate used to authenticate to kubernetes apiserver
@@ -668,6 +736,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.instance }}/{{ $labels.name
@@ -680,6 +750,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -692,6 +764,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -702,6 +776,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -714,6 +790,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-kubelet
       rules:
         - alert: KubeNodeNotReady
@@ -729,6 +807,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodePressure
           annotations:
             description: '{{ $labels.node }} on cluster {{ $labels.cluster }} has
@@ -743,6 +823,8 @@ spec:
           for: 10m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -754,6 +836,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -777,6 +861,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -791,6 +877,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeEviction
           annotations:
             description: Node {{ $labels.node }} on {{ $labels.cluster }} is evicting
@@ -809,6 +897,8 @@ spec:
           for: 0s
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -821,6 +911,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -844,6 +936,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -855,6 +949,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -866,6 +962,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -877,6 +975,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -888,6 +988,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -900,6 +1002,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -912,6 +1016,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery
@@ -925,6 +1031,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-scheduler
       rules:
         - alert: KubeSchedulerDown
@@ -937,6 +1045,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-controller-manager
       rules:
         - alert: KubeControllerManagerDown
@@ -950,6 +1060,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - interval: 3m
       name: kube-apiserver-availability.rules
       rules:

--- a/tests/golden/kubernetes_1.36/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.36/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/multi/prometheus/prometheus/100_other-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/multi/prometheus/prometheus/100_other-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -57,6 +61,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/multi/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/multi/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,3 +108,5 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/multi/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/multi/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -49,6 +51,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -68,6 +72,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -81,6 +87,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -92,6 +100,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -103,6 +113,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -122,6 +134,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -134,6 +148,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -168,6 +186,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -187,6 +207,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -208,6 +230,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -219,6 +243,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -231,6 +257,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -244,6 +272,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -257,6 +287,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -268,6 +300,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -287,3 +321,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/multi/prometheus/prometheus/20_other-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/multi/prometheus/prometheus/20_other-instance_prometheus_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -49,6 +51,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -68,6 +72,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -81,6 +87,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -92,6 +100,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -103,6 +113,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -122,6 +134,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -134,6 +148,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -168,6 +186,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -187,6 +207,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -208,6 +230,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -219,6 +243,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -231,6 +257,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -244,6 +272,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -257,6 +287,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -268,6 +300,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -287,3 +321,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/multi/prometheus/prometheus/90_other-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/multi/prometheus/prometheus/90_other-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/resourcequota/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/resourcequota/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,3 +108,5 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/resourcequota/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/resourcequota/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -71,6 +75,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -86,6 +92,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -105,6 +113,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -124,6 +134,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -139,6 +151,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -154,6 +168,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -166,6 +182,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -178,6 +196,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -188,6 +208,8 @@ spec:
             (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector failed to scrape.
@@ -197,6 +219,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock on {{ $labels.instance }} is out of sync by more than
@@ -218,6 +242,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock on {{ $labels.instance }} is not synchronising. Ensure
@@ -231,6 +257,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' on {{ $labels.instance
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array on {{ $labels.instance
@@ -254,6 +284,8 @@ spec:
             node_md_disks{state="failed"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -267,6 +299,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -280,6 +314,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/rewrite-registries/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
+++ b/tests/golden/rewrite-registries/prometheus/prometheus/100_default-instance_kubePrometheus_prometheusRule.yaml
@@ -29,6 +29,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: Watchdog
           annotations:
             description: |
@@ -43,6 +45,8 @@ spec:
           expr: vector(1)
           labels:
             severity: none
+            syn: 'true'
+            syn_component: prometheus
     - name: node-network
       rules:
         - alert: NodeNetworkInterfaceFlapping
@@ -57,6 +61,8 @@ spec:
           for: 2m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-prometheus-node-recording.rules
       rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))

--- a/tests/golden/rewrite-registries/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/rewrite-registries/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,3 +108,5 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/rewrite-registries/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
+++ b/tests/golden/rewrite-registries/prometheus/prometheus/20_default-instance_prometheus_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -49,6 +51,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -68,6 +72,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -81,6 +87,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -92,6 +100,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -103,6 +113,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -122,6 +134,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -134,6 +148,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -168,6 +186,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -187,6 +207,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -208,6 +230,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -219,6 +243,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -231,6 +257,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -244,6 +272,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -257,6 +287,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -268,6 +300,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -287,3 +321,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/rewrite-registries/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
+++ b/tests/golden/rewrite-registries/prometheus/prometheus/30_default-instance_alertmanager_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -47,6 +49,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -64,6 +68,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -82,6 +88,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -100,6 +108,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -115,6 +125,8 @@ spec:
           for: 20m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterDown
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -137,6 +149,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AlertmanagerClusterCrashlooping
           annotations:
             description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -159,3 +173,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/rewrite-registries/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/rewrite-registries/prometheus/prometheus/50_default-instance_nodeExporter_prometheusRule.yaml
@@ -37,6 +37,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -56,6 +58,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -71,6 +75,8 @@ spec:
           for: 30m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -86,6 +92,8 @@ spec:
           for: 30m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -105,6 +113,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -124,6 +134,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -139,6 +151,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -154,6 +168,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -166,6 +182,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -178,6 +196,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -188,6 +208,8 @@ spec:
             (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector failed to scrape.
@@ -197,6 +219,8 @@ spec:
             node_textfile_scrape_error{job="nodeexporter-default-instance"} == 1
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockSkewDetected
           annotations:
             description: Clock on {{ $labels.instance }} is out of sync by more than
@@ -218,6 +242,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeClockNotSynchronising
           annotations:
             description: Clock on {{ $labels.instance }} is not synchronising. Ensure
@@ -231,6 +257,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' on {{ $labels.instance
@@ -243,6 +271,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array on {{ $labels.instance
@@ -254,6 +284,8 @@ spec:
             node_md_disks{state="failed"} > 0
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -267,6 +299,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -280,6 +314,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: node-exporter.rules
       rules:
         - expr: |

--- a/tests/golden/rewrite-registries/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/rewrite-registries/prometheus/prometheus/70_default-instance_kubernetesControlPlane_prometheusRule.yaml
@@ -27,6 +27,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -44,6 +46,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -58,6 +62,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -78,6 +84,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -98,6 +106,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -112,6 +122,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -139,6 +151,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -172,6 +186,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeContainerWaiting
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{
@@ -183,6 +199,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -196,6 +214,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -207,6 +227,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobCompletion
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -218,6 +240,8 @@ spec:
           for: 12h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -230,6 +254,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-resources
       rules:
         - alert: KubeCPUOvercommit
@@ -245,6 +271,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Pods
@@ -258,6 +286,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeCPUQuotaOvercommit
           annotations:
             description: Cluster has overcommitted CPU resource requests for Namespaces.
@@ -271,6 +301,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Namespaces.
@@ -284,6 +316,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -298,6 +332,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -312,6 +348,8 @@ spec:
           for: 15m
           labels:
             severity: info
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -326,6 +364,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-storage
       rules:
         - alert: KubePersistentVolumeFillingUp
@@ -346,6 +386,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -367,6 +409,8 @@ spec:
           for: 1h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubePersistentVolumeErrors
           annotations:
             description: The persistent volume {{ $labels.persistentvolume }} has
@@ -378,6 +422,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system
       rules:
         - alert: KubeVersionMismatch
@@ -391,6 +437,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientErrors
           annotations:
             description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
@@ -405,6 +453,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-slos
       rules:
         - alert: KubeAPIErrorBudgetBurn
@@ -421,6 +471,8 @@ spec:
             long: 1h
             severity: critical
             short: 5m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -435,6 +487,8 @@ spec:
             long: 6h
             severity: critical
             short: 30m
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -449,6 +503,8 @@ spec:
             long: 1d
             severity: warning
             short: 2h
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget.
@@ -463,6 +519,8 @@ spec:
             long: 3d
             severity: warning
             short: 6h
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-apiserver
       rules:
         - alert: KubeClientCertificateExpiration
@@ -475,6 +533,8 @@ spec:
             apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeClientCertificateExpiration
           annotations:
             description: A client certificate used to authenticate to the apiserver
@@ -485,6 +545,8 @@ spec:
             apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: AggregatedAPIErrors
           annotations:
             description: An aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -496,6 +558,8 @@ spec:
             sum by(name, namespace)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: AggregatedAPIDown
           annotations:
             description: An aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -507,6 +571,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -517,6 +583,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeAPITerminatedRequests
           annotations:
             description: The apiserver has terminated {{ $value | humanizePercentage
@@ -529,6 +597,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-kubelet
       rules:
         - alert: KubeNodeNotReady
@@ -541,6 +611,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -552,6 +624,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -569,6 +643,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -580,6 +656,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -591,6 +669,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -602,6 +682,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -612,6 +694,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateExpiration
           annotations:
             description: Client certificate for Kubelet on node {{ $labels.node }}
@@ -622,6 +706,8 @@ spec:
             kubelet_certificate_manager_client_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -632,6 +718,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 604800
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateExpiration
           annotations:
             description: Server certificate for Kubelet on node {{ $labels.node }}
@@ -642,6 +730,8 @@ spec:
             kubelet_certificate_manager_server_ttl_seconds < 86400
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -653,6 +743,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -664,6 +756,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -674,6 +768,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-scheduler
       rules:
         - alert: KubeSchedulerDown
@@ -686,6 +782,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kubernetes-system-controller-manager
       rules:
         - alert: KubeControllerManagerDown
@@ -699,6 +797,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
     - name: kube-apiserver-burnrate.rules
       rules:
         - expr: |

--- a/tests/golden/rewrite-registries/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/rewrite-registries/prometheus/prometheus/90_default-instance_kubeStateMetrics_prometheusRule.yaml
@@ -33,6 +33,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -48,6 +50,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardingMismatch
           annotations:
             description: kube-state-metrics pods are running with different --total-shards
@@ -60,6 +64,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: KubeStateMetricsShardsMissing
           annotations:
             description: kube-state-metrics shards are missing, some Kubernetes objects
@@ -74,3 +80,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/thanos/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
+++ b/tests/golden/thanos/prometheus/prometheus/10_prometheusOperator_prometheusRule.yaml
@@ -28,6 +28,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -39,6 +41,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -50,6 +54,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -62,6 +68,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -73,6 +81,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -84,6 +94,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -96,3 +108,5 @@ spec:
           for: 5m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus

--- a/tests/golden/thanos/prometheus/prometheus/20_test_prometheus_prometheusRule.yaml
+++ b/tests/golden/thanos/prometheus/prometheus/20_test_prometheus_prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -49,6 +51,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -68,6 +72,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -81,6 +87,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -92,6 +100,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -103,6 +113,8 @@ spec:
           for: 4h
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -122,6 +134,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -134,6 +148,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -146,6 +162,8 @@ spec:
           for: 10m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -168,6 +186,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -187,6 +207,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -208,6 +230,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -219,6 +243,8 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -231,6 +257,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -244,6 +272,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -257,6 +287,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -268,6 +300,8 @@ spec:
           for: 5m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
             description: '{{ printf "%.1f" $value }}% minimum errors while sending
@@ -287,3 +321,5 @@ spec:
           for: 15m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: prometheus


### PR DESCRIPTION
This PR refactors the component to use the newly introduced generic library for alert patching provided in the [Project Syn jsonnet-libs](https://github.com/projectsyn/jsonnet-libs/) repository.

For the functionality within this component, the usage of `renderGroups()` and `filterPatchRules()` instead of the previous custom implementations only introduces cosmetic changes in the resulting `PrometheusRule` resources: all alerts now have labels `syn=true` and `syn_component=prometheus` in addition to their existing labels and annotations.

Additionally, the PR introduces two component library aliases `prom.libsonnet` and `alert-patching.libsonnet` whose APIs match the APIs of the same aliases defined in `component-openshift4-monitoring`. These libraries offer functionality that's backed by the generic library where it makes sense and will allow other components to apply consistent transformations on their own alerts by  simply importing `lib/alert-patching.libsonnet` without having to figure out whether they're getting compiled for OpenShift or another K8s distribution.

Side note: This is the first real world test of Commodore's library alias feature to provide component-specific implementations for a shared API, but since we don't expect to ever have a cluster which includes both this component and `component-openshift4-monitoring` the feature should work fine.

See also https://github.com/projectsyn/jsonnet-libs/pull/13 https://github.com/projectsyn/jsonnet-libs/pull/15 and https://github.com/appuio/component-openshift4-monitoring/pull/280

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
